### PR TITLE
Add missing timestamp on histogram

### DIFF
--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -619,7 +619,7 @@ static int add_metric_histogram(struct cmt_decode_prometheus_context *context)
         context->current.histogram = h;
     }
 
-    if (cmt_histogram_set_default(h, 0, bucket_defaults, sum, count,
+    if (cmt_histogram_set_default(h, timestamp, bucket_defaults, sum, count,
                 label_i,
                 label_i ? values_without_le : NULL)) {
         ret = report_error(context,


### PR DESCRIPTION
See https://github.com/calyptia/cmetrics/pull/117

Most probably this change missed from original PR, because value of 'timestamp' was never been used in `add_metric_histogram`

cc @leonardo-albertovich 
