### PR TITLE
build: tarball: Support submoduled directories bundling for tarball creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,4 +347,7 @@ if(CMT_SYSTEM_MACOS)
   endif()
 endif()
 
+# Create tarball
+add_custom_target(tarball COMMAND "bash" "${CMAKE_CURRENT_SOURCE_DIR}/create-submoduled-tarball.sh" "cmetrics-${CMT_VERSION_STR}")
+
 include(CPack)

--- a/create-submoduled-tarball.sh
+++ b/create-submoduled-tarball.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Specify archive name"
+    exit 1
+fi
+
+OS=$(uname -s)
+
+echo "$OS"
+if [ "$OS" == "Darwin" ]; then
+    echo "Using gtar for contatinate option"
+    TAR=gtar
+else
+    TAR=tar
+fi
+
+ROOT_ARCHIVE_NAME=$1
+
+git archive --prefix "$ROOT_ARCHIVE_NAME/" -o "$ROOT_ARCHIVE_NAME.tar" HEAD
+git submodule foreach --recursive "git archive --prefix=$ROOT_ARCHIVE_NAME/\$path/ --output=\$sha1.tar HEAD && $TAR --concatenate --file=$(pwd)/$ROOT_ARCHIVE_NAME.tar \$sha1.tar && rm \$sha1.tar"
+
+gzip "$ROOT_ARCHIVE_NAME.tar"


### PR DESCRIPTION
This added task can be executed by `make tarball`.
Without submoduled source bundling support, user should install git and execute git submodule update --init when starting to build.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>