### PR TITLE
encoding: splunk_hec: Use scientific form on exponential format

### DIFF
--- a/src/cmt_encode_splunk_hec.c
+++ b/src/cmt_encode_splunk_hec.c
@@ -40,7 +40,12 @@ static cfl_sds_t double_to_string(double val)
     }
 
     len = snprintf(str, 64, "%g", val);
-    cfl_sds_len_set(str, len);
+    if (strstr(str, "e+")) {
+        len = snprintf(str, 64, "%e", val);
+        cfl_sds_len_set(str, len);
+    } else {
+        cfl_sds_len_set(str, len);
+    }
 
     if (!strchr(str, '.')) {
         cfl_sds_cat_safe(&str, ".0", 2);


### PR DESCRIPTION
For example, 1e+10 is not valid form for Splunk.
Instead, we have to use 1.0e+10 or more zeroed format such as 1.000000e+10 is valid for Splunk metrics.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>