### PR TITLE
feat: store aggregation type

### DIFF
--- a/include/cmetrics/cmt_decode_msgpack.h
+++ b/include/cmetrics/cmt_decode_msgpack.h
@@ -53,6 +53,7 @@ struct cmt_msgpack_decode_context {
     double            *quantile_list;
     size_t             quantile_count;
     uint64_t           summary_quantiles[5];
+    int                aggregation_type;
 };
 
 int cmt_decode_msgpack_create(struct cmt **out_cmt, char *in_buf, size_t in_size, 

--- a/src/cmt_counter.c
+++ b/src/cmt_counter.c
@@ -73,6 +73,8 @@ struct cmt_counter *cmt_counter_create(struct cmt *cmt,
         cmt_counter_destroy(counter);
         return NULL;
     }
+    /* set default counter aggregation type to cumulative */
+    counter->aggregation_type = CMT_AGGREGATION_TYPE_CUMULATIVE;
 
     counter->cmt = cmt;
     return counter;

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -800,6 +800,30 @@ static int unpack_meta_type(mpack_reader_t *reader, size_t index, void *context)
     return result;
 }
 
+static int unpack_agg_type(mpack_reader_t *reader, size_t index, void *context)
+{
+    uint64_t                           value;
+    int                                result;
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    result = cmt_mpack_consume_uint_tag(reader, &value);
+
+    if (CMT_DECODE_MSGPACK_SUCCESS == result) {
+        decode_context->aggregation_type = value;
+
+        result = create_metric_instance(decode_context->map);
+    }
+
+    return result;
+}
+
 static int unpack_meta_opts(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
@@ -933,6 +957,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
     int                                   result;
     struct cmt_summary                   *summary;
     struct cmt_histogram                 *histogram;
+    struct cmt_counter                   *counter;
     struct cmt_msgpack_decode_context    *decode_context;
     struct cmt_mpack_map_entry_callback_t callbacks[] = \
         {
@@ -942,6 +967,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             {"labels",           unpack_meta_labels},
             {"buckets",          unpack_meta_buckets},
             {"quantiles",        unpack_meta_quantiles},
+            {"agg_type",         unpack_agg_type},
             {NULL,               NULL}
         };
 
@@ -980,6 +1006,10 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             if (summary->quantiles == NULL) {
                 result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
             }
+        }
+        else if(decode_context->map->type == CMT_COUNTER) {
+            counter = (struct counter *) decode_context->map->parent;
+            counter->aggregation_type = decode_context->aggregation_type;
         }
     }
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -800,7 +800,7 @@ static int unpack_meta_type(mpack_reader_t *reader, size_t index, void *context)
     return result;
 }
 
-static int unpack_agg_type(mpack_reader_t *reader, size_t index, void *context)
+static int unpack_meta_aggregation_type(mpack_reader_t *reader, size_t index, void *context)
 {
     uint64_t                           value;
     int                                result;
@@ -967,7 +967,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             {"labels",           unpack_meta_labels},
             {"buckets",          unpack_meta_buckets},
             {"quantiles",        unpack_meta_quantiles},
-            {"agg_type",         unpack_agg_type},
+            {"agg_type",         unpack_meta_aggregation_type},
             {NULL,               NULL}
         };
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -817,8 +817,6 @@ static int unpack_meta_aggregation_type(mpack_reader_t *reader, size_t index, vo
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
         decode_context->aggregation_type = value;
-
-        result = create_metric_instance(decode_context->map);
     }
 
     return result;

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -965,7 +965,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             {"labels",           unpack_meta_labels},
             {"buckets",          unpack_meta_buckets},
             {"quantiles",        unpack_meta_quantiles},
-            {"agg_type",         unpack_meta_aggregation_type},
+            {"aggregation_type", unpack_meta_aggregation_type},
             {NULL,               NULL}
         };
 

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -56,6 +56,7 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     size_t                index;
     struct cmt_summary   *summary = NULL;
     struct cmt_histogram *histogram = NULL;
+    struct cmt_counter   *counter = NULL;
     size_t                meta_field_count;
 
     opts = map->opts;
@@ -66,8 +67,13 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
 
         meta_field_count++;
     }
-    if (map->type == CMT_SUMMARY) {
+    else if (map->type == CMT_SUMMARY) {
         summary = (struct cmt_summary *) map->parent;
+
+        meta_field_count++;
+    }
+    else if (map->type == CMT_COUNTER){
+        counter = (struct cmt_counter *) map->parent;
 
         meta_field_count++;
     }
@@ -143,6 +149,11 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
         }
 
         mpack_finish_array(writer);
+    }
+    else if (map->type == CMT_COUNTER){
+        /* aggregation_type */
+        mpack_write_cstr(writer, "agg_type");
+        mpack_write_int(writer, counter->aggregation_type);
     }
 
     mpack_finish_map(writer); /* 'meta' */

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -152,7 +152,7 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     }
     else if (map->type == CMT_COUNTER){
         /* aggregation_type */
-        mpack_write_cstr(writer, "agg_type");
+        mpack_write_cstr(writer, "aggregation_type");
         mpack_write_int(writer, counter->aggregation_type);
     }
 


### PR DESCRIPTION
The goal is to store the aggregation type when encoding in msgpack format.
This will fix this issue: https://github.com/fluent/fluent-bit/issues/6303