### PR TITLE
decode: remove summary quantile limit.

### DIFF
--- a/include/cmetrics/cmt_decode_msgpack.h
+++ b/include/cmetrics/cmt_decode_msgpack.h
@@ -52,7 +52,8 @@ struct cmt_msgpack_decode_context {
     size_t             bucket_count;
     double            *quantile_list;
     size_t             quantile_count;
-    uint64_t           summary_quantiles[5];
+    uint64_t           *summary_quantiles;
+    size_t             summary_quantiles_count;
     int                aggregation_type;
 };
 

--- a/include/cmetrics/cmt_metric.h
+++ b/include/cmetrics/cmt_metric.h
@@ -34,6 +34,7 @@ struct cmt_metric {
     /* summary */
     int sum_quantiles_set;     /* specify if quantive values has been set */
     uint64_t *sum_quantiles;   /* 0, 0.25, 0.5, 0.75 and 1 */
+    size_t sum_quantiles_count;
     uint64_t sum_count;
     uint64_t sum_sum;
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -31,9 +31,6 @@
 #include <cmetrics/cmt_variant_utils.h>
 #include <cmetrics/cmt_mpack_utils.h>
 
-#ifndef CMT_SUMMARY_QUANTILE_ELEMENT_LIMIT
-#define CMT_SUMMARY_QUANTILE_ELEMENT_LIMIT 5
-#endif
 
 static int create_counter_instance(struct cmt_map *map)
 {
@@ -442,11 +439,6 @@ static int unpack_summary_quantile(mpack_reader_t *reader, size_t index, void *c
     }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
-
-    if (index >= CMT_SUMMARY_QUANTILE_ELEMENT_LIMIT) {
-        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
-    }
-
     return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->sum_quantiles[index]);
 }
 
@@ -677,6 +669,7 @@ static int unpack_metric(mpack_reader_t *reader,
 
             return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
         }
+        metric->sum_quantiles_count = summary->quantiles_count;
     }
 
     cfl_list_init(&metric->labels);
@@ -1000,10 +993,6 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
 
             decode_context->quantile_list = NULL;
             decode_context->quantile_count = 0;
-
-            if (summary->quantiles == NULL) {
-                result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
-            }
         }
         else if(decode_context->map->type == CMT_COUNTER) {
             counter = (struct counter *) decode_context->map->parent;

--- a/src/cmt_decode_opentelemetry.c
+++ b/src/cmt_decode_opentelemetry.c
@@ -561,6 +561,7 @@ static int decode_summary_data_point(struct cmt *cmt,
             }
 
             sample->sum_quantiles_set = CMT_TRUE;
+            sample->sum_quantiles_count = data_point->n_quantile_values;
         }
 
         for (index = 0 ;

--- a/src/cmt_summary.c
+++ b/src/cmt_summary.c
@@ -130,7 +130,7 @@ double cmt_summary_quantile_get_value(struct cmt_metric *metric, int quantile_id
 {
     uint64_t val;
 
-    if (quantile_id < 0 || quantile_id > 5) {
+    if (quantile_id < 0 /*|| quantile_id > metric->sum_quantiles_count*/) {
         return 0;
     }
 
@@ -285,6 +285,7 @@ int cmt_summary_set_default(struct cmt_summary *summary,
             cmt_errno();
             return -1;
         }
+        metric->sum_quantiles_count = summary->quantiles_count;
     }
 
     /* set quantile values */


### PR DESCRIPTION
Remove the self-imposed limit of 5 quantile summaries, re #167. This causes a bug when decoding prometheus metrics.