### PR TITLE
decode: prometheus: Fix when consecutive metrics have differnet label count

### DIFF
--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -34,6 +34,7 @@
 #include <cmt_decode_prometheus_parser.h>
 #include <stdio.h>
 #include <string.h>
+#include <cmetrics/cmt_map.h>
 
 static void reset_context(struct cmt_decode_prometheus_context *context,
                           bool reset_summary)
@@ -591,7 +592,7 @@ static int add_metric_histogram(struct cmt_decode_prometheus_context *context)
     }
 
     h = context->current.histogram;
-    if (!h) {
+    if (!h || label_i != h->map->label_count) {
         cmt_buckets = cmt_histogram_buckets_create_size(buckets, bucket_count);
         if (!cmt_buckets) {
             ret = report_error(context,
@@ -806,7 +807,7 @@ static int add_metric_summary(struct cmt_decode_prometheus_context *context)
     }
 
     s = context->current.summary;
-    if (!s) {
+    if (!s || label_i != s->map->label_count) {
         s = cmt_summary_create(context->cmt,
                                context->metric.ns,
                                context->metric.subsystem,

--- a/tests/data/histogram_different_label_count.txt
+++ b/tests/data/histogram_different_label_count.txt
@@ -1,0 +1,14 @@
+# HELP k8s_network_load Network load
+# TYPE k8s_network_load histogram
+k8s_network_load_bucket{le="0.05"} 0 0
+k8s_network_load_bucket{le="5.0"} 1 0
+k8s_network_load_bucket{le="10.0"} 2 0
+k8s_network_load_bucket{le="+Inf"} 3 0
+k8s_network_load_sum 1013 0
+k8s_network_load_count 3 0
+k8s_network_load_bucket{le="0.05",my_label="my_val"} 0 0
+k8s_network_load_bucket{le="5.0",my_label="my_val"} 1 0
+k8s_network_load_bucket{le="10.0",my_label="my_val"} 2 0
+k8s_network_load_bucket{le="+Inf",my_label="my_val"} 3 0
+k8s_network_load_sum{my_label="my_val"} 1013 0
+k8s_network_load_count{my_label="my_val"} 3 0


### PR DESCRIPTION
Since cmt_map does not allow different label count when fetching metrics, we create a different cmt_histogram/cmt_summary when the label count is different.

Signed-off-by: Thiago Padilha <thiago@calyptia.com>