### PR TITLE
decode: msgpack empty histogram fix

### DIFF
--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -126,12 +126,17 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
         /* 'buckets' (histogram buckets) */
         mpack_write_cstr(writer, "buckets");
 
-        mpack_start_array(writer, histogram->buckets->count);
+        if (histogram->buckets != NULL) {
+            mpack_start_array(writer, histogram->buckets->count);
 
-        for (index = 0 ;
-             index < histogram->buckets->count ;
-             index++) {
-            mpack_write_double(writer, histogram->buckets->upper_bounds[index]);
+            for (index = 0 ;
+                 index < histogram->buckets->count ;
+                 index++) {
+                mpack_write_double(writer, histogram->buckets->upper_bounds[index]);
+            }
+        }
+        else {
+            mpack_start_array(writer, 0);
         }
 
         mpack_finish_array(writer);


### PR DESCRIPTION
This code fixes a bug in the msgpack encoder that caused a crash when trying to encode histograms with no buckets set up.

This happened when ingesting an opentelemetry packet with an empty histogram such as this : 

```
        metrics {
            name: "http.client.duration"
            description: "measures the duration of the outbound HTTP requests"
            unit: "ms"
            histogram {
                aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
            }
        }
```

With this patch the msgpack encoder will not try to dereference the `buckets` member to create the array when the histogram has not been set up and the msgpack decoder will handle the use case properly as well (as it previously expected the bucket count to be higher than zero).

Acknowledgement : Thanks Henrik Rexed for reporting the bug and providing the information necessary to find the root cause.