### PR TITLE
encoding: opentelemetry: switched the type untyped metrics are casted to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 # CMetrics Version
 set(CMT_VERSION_MAJOR  0)
 set(CMT_VERSION_MINOR  6)
-set(CMT_VERSION_PATCH  1)
+set(CMT_VERSION_PATCH  2)
 set(CMT_VERSION_STR "${CMT_VERSION_MAJOR}.${CMT_VERSION_MINOR}.${CMT_VERSION_PATCH}")
 
 # Define __CMT_FILENAME__ consistently across Operating Systems


### PR DESCRIPTION
This PR makes the opentelemetry encoder promote untyped metrics to gauges instead of sums to overcome an issue reported by Ignacio Coterillo.