### PR TITLE
math: fix cast

### DIFF
--- a/include/cmetrics/cmt_math.h
+++ b/include/cmetrics/cmt_math.h
@@ -23,11 +23,6 @@
 #include <inttypes.h>
 #include <string.h>
 
-union val_union {
-    uint64_t u;
-    double d;
-};
-
 /*
  * This is not rocket-science and to make things easier we assume that operating on
  * floating pointer numbers we will lose precision. So we just do simple casts.
@@ -35,18 +30,12 @@ union val_union {
 
 static inline uint64_t cmt_math_d64_to_uint64(double val)
 {
-    union val_union u;
-
-    u.d = val;
-    return u.u;
+    return (uint64_t)val;
 }
 
 static inline double cmt_math_uint64_to_d64(uint64_t val)
 {
-    union val_union u;
-
-    u.u = val;
-    return u.d;
+    return (double)val;
 }
 
 #endif


### PR DESCRIPTION
Fixes #184 

This patch is to revert math casting.

This patch may break following patches.
https://github.com/fluent/cmetrics/commit/ee89bd63d8e589b70cff60a250c7954c1df5b7f2
https://github.com/fluent/cmetrics/commit/ce1fde8e593ef030108aebca17f8b7d07c390d1c#diff-a89fcf4d45cb051277d5d437807208b3642c276927c62807ff611f66e0ef4de7