### PR TITLE
CMakeLists.txt: fix ninja build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 # Define __CMT_FILENAME__ consistently across Operating Systems
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__=__FILE__")
 endif()


### PR DESCRIPTION
CMake Error:
Running

'/usr/bin/ninja' '-C' '/home/thode/external/cfl/CMakeFiles/CMakeTmp' '-t' 'recompact'

failed with:

ninja: error: build.ninja:50: bad $-escape (literal $ must be written as $$)