### PR TITLE
decode: fix possible NULL dereference

### DIFF
--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -977,11 +977,11 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
     result = cmt_mpack_unpack_map(reader, callbacks, context);
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
-        decode_context->map->label_count = cfl_list_size(&decode_context->map->label_keys);
 	if (decode_context->map == NULL || decode_context->map->parent == NULL) {
             return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
 	}
 
+        decode_context->map->label_count = cfl_list_size(&decode_context->map->label_keys);
         if (decode_context->map->type == CMT_HISTOGRAM) {
             histogram = (struct cmt_histogram *) decode_context->map->parent;
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -978,6 +978,9 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
         decode_context->map->label_count = cfl_list_size(&decode_context->map->label_keys);
+	if (decode_context->map == NULL || decode_context->map->parent == NULL) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+	}
 
         if (decode_context->map->type == CMT_HISTOGRAM) {
             histogram = (struct cmt_histogram *) decode_context->map->parent;
@@ -1006,12 +1009,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
         }
         else if(decode_context->map->type == CMT_COUNTER) {
             counter = (struct cmt_counter *) decode_context->map->parent;
-            if (counter == NULL) {
-                result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
-            }
-            else {
-                counter->aggregation_type = decode_context->aggregation_type;
-            }
+            counter->aggregation_type = decode_context->aggregation_type;
         }
     }
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -1006,7 +1006,12 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
         }
         else if(decode_context->map->type == CMT_COUNTER) {
             counter = (struct cmt_counter *) decode_context->map->parent;
-            counter->aggregation_type = decode_context->aggregation_type;
+            if (counter == NULL) {
+                result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+            }
+            else {
+                counter->aggregation_type = decode_context->aggregation_type;
+            }
         }
     }
 


### PR DESCRIPTION
Found by a recently added fuzzer.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61743