### PR TITLE
Implement filtering mechanism for cmetrics context

### DIFF
--- a/include/cmetrics/cmt_cat.h
+++ b/include/cmetrics/cmt_cat.h
@@ -28,11 +28,11 @@ struct cmt_untyped;
 struct cmt_histogram;
 struct cmt_summary;
 
-int cmt_cat_copy_counter(struct cmt *cmt, struct cmt_counter *counter);
-int cmt_cat_copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge);
-int cmt_cat_copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped);
-int cmt_cat_copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram);
-int cmt_cat_copy_summary(struct cmt *cmt, struct cmt_summary *summary);
+int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter);
+int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge);
+int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped);
+int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram);
+int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary);
 int cmt_cat(struct cmt *dst, struct cmt *src);
 
 #endif

--- a/include/cmetrics/cmt_cat.h
+++ b/include/cmetrics/cmt_cat.h
@@ -22,6 +22,17 @@
 
 #include <cmetrics/cmetrics.h>
 
+struct cmt_counter;
+struct cmt_gauge;
+struct cmt_untyped;
+struct cmt_histogram;
+struct cmt_summary;
+
+int cmt_cat_copy_counter(struct cmt *cmt, struct cmt_counter *counter);
+int cmt_cat_copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge);
+int cmt_cat_copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped);
+int cmt_cat_copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram);
+int cmt_cat_copy_summary(struct cmt *cmt, struct cmt_summary *summary);
 int cmt_cat(struct cmt *dst, struct cmt *src);
 
 #endif

--- a/include/cmetrics/cmt_filter.h
+++ b/include/cmetrics/cmt_filter.h
@@ -23,9 +23,10 @@
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_cat.h>
 
-#define CMT_FILTER_EXCLUDE   (1 << 1)
-#define CMT_FILTER_PREFIX    (1 << 2)
-#define CMT_FILTER_SUBSTRING (1 << 3)
+#define CMT_FILTER_EXCLUDE             (1 << 1)
+#define CMT_FILTER_PREFIX              (1 << 2)
+#define CMT_FILTER_SUBSTRING           (1 << 3)
+#define CMT_FILTER_REGEX_SEARCH_LABELS (1 << 4)
 
 #define CMT_FILTER_SUCCESS           0
 #define CMT_FILTER_INVALID_ARGUMENT -1

--- a/include/cmetrics/cmt_filter.h
+++ b/include/cmetrics/cmt_filter.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021-2024 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CMT_FILTER_H
+#define CMT_FILTER_H
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_cat.h>
+
+#define CMT_FILTER_EXCLUDE   (1 << 1)
+#define CMT_FILTER_PREFIX    (1 << 2)
+#define CMT_FILTER_SUBSTRING (1 << 3)
+
+#define CMT_FILTER_SUCCESS           0
+#define CMT_FILTER_INVALID_ARGUMENT -1
+#define CMT_FILTER_INVALID_FLAGS    -2
+#define CMT_FILTER_FAILED_OPERATION -3
+
+int cmt_filter(struct cmt *dst, struct cmt *src,
+               const char *fqname, const char *label_key,
+               int flags);
+
+#endif

--- a/include/cmetrics/cmt_filter.h
+++ b/include/cmetrics/cmt_filter.h
@@ -34,6 +34,7 @@
 
 int cmt_filter(struct cmt *dst, struct cmt *src,
                const char *fqname, const char *label_key,
+               void *compare_ctx, int (*compare)(void *compare_ctx, const char *str, size_t slen),
                int flags);
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(src
   cmt_time.c
   cmt_label.c
   cmt_cat.c
+  cmt_filter.c
   cmetrics.c
   cmt_encode_opentelemetry.c
   cmt_decode_opentelemetry.c

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -178,7 +178,7 @@ static int copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *
 
 }
 
-static int copy_counter(struct cmt *cmt, struct cmt_counter *counter)
+int cmt_cat_copy_counter(struct cmt *cmt, struct cmt_counter *counter)
 {
     int ret;
     char **labels = NULL;
@@ -213,7 +213,7 @@ static int copy_counter(struct cmt *cmt, struct cmt_counter *counter)
     return 0;
 }
 
-static int copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
+int cmt_cat_copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
 {
     int ret;
     char **labels = NULL;
@@ -247,7 +247,7 @@ static int copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
     return 0;
 }
 
-static int copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
+int cmt_cat_copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
 {
     int ret;
     char **labels = NULL;
@@ -281,7 +281,7 @@ static int copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
     return 0;
 }
 
-static int copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
+int cmt_cat_copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
 {
     int i;
     double val;
@@ -331,7 +331,7 @@ static int copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
     return 0;
 }
 
-static int copy_summary(struct cmt *cmt, struct cmt_summary *summary)
+int cmt_cat_copy_summary(struct cmt *cmt, struct cmt_summary *summary)
 {
     int i;
     int ret;
@@ -395,7 +395,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
      /* Counters */
     cfl_list_foreach(head, &src->counters) {
         counter = cfl_list_entry(head, struct cmt_counter, _head);
-        ret = copy_counter(dst, counter);
+        ret = cmt_cat_copy_counter(dst, counter);
         if (ret == -1) {
             return -1;
         }
@@ -404,7 +404,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Gauges */
     cfl_list_foreach(head, &src->gauges) {
         gauge = cfl_list_entry(head, struct cmt_gauge, _head);
-        ret = copy_gauge(dst, gauge);
+        ret = cmt_cat_copy_gauge(dst, gauge);
         if (ret == -1) {
             return -1;
         }
@@ -413,7 +413,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Untyped */
     cfl_list_foreach(head, &src->untypeds) {
         untyped = cfl_list_entry(head, struct cmt_untyped, _head);
-        ret = copy_untyped(dst, untyped);
+        ret = cmt_cat_copy_untyped(dst, untyped);
         if (ret == -1) {
             return -1;
         }
@@ -422,7 +422,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Histogram */
     cfl_list_foreach(head, &src->histograms) {
         histogram = cfl_list_entry(head, struct cmt_histogram, _head);
-        ret = copy_histogram(dst, histogram);
+        ret = cmt_cat_copy_histogram(dst, histogram);
         if (ret == -1) {
             return -1;
         }
@@ -431,7 +431,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Summary */
     cfl_list_foreach(head, &src->summaries) {
         summary = cfl_list_entry(head, struct cmt_summary, _head);
-        ret = copy_summary(dst, summary);
+        ret = cmt_cat_copy_summary(dst, summary);
         if (ret == -1) {
             return -1;
         }

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -178,7 +178,7 @@ static int copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *
 
 }
 
-int cmt_cat_copy_counter(struct cmt *cmt, struct cmt_counter *counter)
+int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter)
 {
     int ret;
     char **labels = NULL;
@@ -213,7 +213,7 @@ int cmt_cat_copy_counter(struct cmt *cmt, struct cmt_counter *counter)
     return 0;
 }
 
-int cmt_cat_copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
+int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
 {
     int ret;
     char **labels = NULL;
@@ -247,7 +247,7 @@ int cmt_cat_copy_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
     return 0;
 }
 
-int cmt_cat_copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
+int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
 {
     int ret;
     char **labels = NULL;
@@ -281,7 +281,7 @@ int cmt_cat_copy_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
     return 0;
 }
 
-int cmt_cat_copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
+int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
 {
     int i;
     double val;
@@ -331,7 +331,7 @@ int cmt_cat_copy_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
     return 0;
 }
 
-int cmt_cat_copy_summary(struct cmt *cmt, struct cmt_summary *summary)
+int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary)
 {
     int i;
     int ret;
@@ -395,7 +395,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
      /* Counters */
     cfl_list_foreach(head, &src->counters) {
         counter = cfl_list_entry(head, struct cmt_counter, _head);
-        ret = cmt_cat_copy_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter);
         if (ret == -1) {
             return -1;
         }
@@ -404,7 +404,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Gauges */
     cfl_list_foreach(head, &src->gauges) {
         gauge = cfl_list_entry(head, struct cmt_gauge, _head);
-        ret = cmt_cat_copy_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge);
         if (ret == -1) {
             return -1;
         }
@@ -413,7 +413,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Untyped */
     cfl_list_foreach(head, &src->untypeds) {
         untyped = cfl_list_entry(head, struct cmt_untyped, _head);
-        ret = cmt_cat_copy_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped);
         if (ret == -1) {
             return -1;
         }
@@ -422,7 +422,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Histogram */
     cfl_list_foreach(head, &src->histograms) {
         histogram = cfl_list_entry(head, struct cmt_histogram, _head);
-        ret = cmt_cat_copy_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram);
         if (ret == -1) {
             return -1;
         }
@@ -431,7 +431,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Summary */
     cfl_list_foreach(head, &src->summaries) {
         summary = cfl_list_entry(head, struct cmt_summary, _head);
-        ret = cmt_cat_copy_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary);
         if (ret == -1) {
             return -1;
         }

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -35,10 +35,12 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
     struct cmt_map_label *label;
     size_t label_key_size = 0;
 
-    if (flags & CMT_FILTER_PREFIX && label_key != NULL) {
-        label_key_size = strlen(label_key);
+    if (flags & CMT_FILTER_PREFIX) {
+        if (label_key == NULL) {
+            return CMT_FALSE;
+        }
 
-        return CMT_FALSE;
+        label_key_size = strlen(label_key);
     }
 
     cfl_list_foreach(head, &src->label_keys) {

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -62,7 +62,7 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
         /* Compare with an external context (e.g. Onigmo).
          * flb_regex_match should take three arguments that are
          * flb_regex context, string and its string length.
-         * The length of string is changed and not determined by label_key.
+         * The length of string is changed by the callback and not determined by label_key.
          */
         if (compare_ctx != NULL && compare != NULL) {
             return compare(compare_ctx, label->name, strlen(label->name));
@@ -183,7 +183,7 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
     /* Compare with an external context (e.g. Onigmo).
      * flb_regex_match should take three arguments that are
      * flb_regex context, string and its string length.
-     * The length of string is changed and not determined by fqname.
+     * The length of string is changed by the callback and not determined by fqname.
      */
     if (compare_ctx != NULL && compare != NULL) {
         return compare(compare_ctx, src->fqname, strlen(src->fqname));

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -189,11 +189,7 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
         return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
     }
 
-    /* Compare with an external context (e.g. Onigmo).
-     * flb_regex_match should take three arguments that are
-     * flb_regex context, string and its string length.
-     * The length of string is changed by the callback and not determined by fqname.
-     */
+    /* Compare with an external context (e.g. Onigmo). */
     if (compare_ctx != NULL && compare != NULL) {
         return compare(compare_ctx, src->fqname, fqname_size);
     }

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -169,6 +169,10 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
     size_t fqname_size;
 
     if (flags & CMT_FILTER_PREFIX) {
+        if (fqname == NULL) {
+            return CMT_FALSE;
+        }
+
         fqname_size = strlen(fqname);
     }
     else if (compare_ctx != NULL && compare != NULL) {

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -35,7 +35,7 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
     struct cmt_map_label *label;
     size_t label_key_size = 0;
 
-    if (label_key != NULL) {
+    if (flags & CMT_FILTER_PREFIX && label_key != NULL) {
         label_key_size = strlen(label_key);
     }
 
@@ -162,9 +162,18 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
                           void *compare_ctx, int (*compare)(void *compare_ctx, const char *str, size_t slen),
                           int flags)
 {
+    size_t fqname_size;
+
+    if (flags & CMT_FILTER_PREFIX) {
+        fqname_size = strlen(fqname);
+    }
+    else if (compare_ctx != NULL && compare != NULL) {
+        fqname_size = strlen(src->fqname);
+    }
+
     /* compare fqname for prefix */
     if (flags & CMT_FILTER_PREFIX) {
-        if (strncmp(src->fqname, fqname, strlen(fqname)) == 0) {
+        if (strncmp(src->fqname, fqname, fqname_size) == 0) {
             return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
         }
 
@@ -186,7 +195,7 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
      * The length of string is changed by the callback and not determined by fqname.
      */
     if (compare_ctx != NULL && compare != NULL) {
-        return compare(compare_ctx, src->fqname, strlen(src->fqname));
+        return compare(compare_ctx, src->fqname, fqname_size);
     }
 
     return CMT_FALSE;

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -1,0 +1,282 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021-2024 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_log.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_untyped.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_filter.h>
+
+static int compare_label_keys(struct cmt_map *src, const char *label_key, int flags)
+{
+    struct cfl_list *head;
+    struct cmt_map_label *label;
+
+    cfl_list_foreach(head, &src->label_keys) {
+        label = cfl_list_entry(head, struct cmt_map_label, _head);
+        /* compare label_keys for prefix */
+        if (flags & CMT_FILTER_PREFIX) {
+            if (strncmp(label->name, label_key, strlen(label_key)) == 0) {
+                return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
+            }
+
+            return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
+        }
+
+        /* compare label_keys for substring */
+        if (flags & CMT_FILTER_SUBSTRING) {
+            if (strstr(label->name, label_key) != NULL) {
+                return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
+            }
+
+            return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
+        }
+    }
+
+    return CMT_FALSE;
+}
+
+static int filter_context_label_key(struct cmt *dst, struct cmt *src,
+                                    const char *label_key, int flags)
+{
+    int ret;
+    struct cfl_list *head;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_untyped *untyped;
+    struct cmt_histogram *histogram;
+    struct cmt_summary *summary;
+
+     /* Counters */
+    cfl_list_foreach(head, &src->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+
+        if (compare_label_keys(counter->map, label_key, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_counter(dst, counter);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Gauges */
+    cfl_list_foreach(head, &src->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+
+        if (compare_label_keys(gauge->map, label_key, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_gauge(dst, gauge);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Untyped */
+    cfl_list_foreach(head, &src->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+
+        if (compare_label_keys(untyped->map, label_key, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_untyped(dst, untyped);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Histogram */
+    cfl_list_foreach(head, &src->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+
+        if (compare_label_keys(histogram->map, label_key, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_histogram(dst, histogram);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Summary */
+    cfl_list_foreach(head, &src->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+
+        if (compare_label_keys(summary->map, label_key, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_summary(dst, summary);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    return CMT_FILTER_SUCCESS;
+}
+
+static int compare_fqname(struct cmt_opts *src, const char *fqname, int flags)
+{
+    /* compare fqname for prefix */
+    if (flags & CMT_FILTER_PREFIX) {
+        if (strncmp(src->fqname, fqname, strlen(fqname)) == 0) {
+            return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
+        }
+
+        return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
+    }
+
+    /* compare fqname for substring */
+    if (flags & CMT_FILTER_SUBSTRING) {
+        if (strstr(src->fqname, fqname) != NULL) {
+            return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
+        }
+
+        return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
+    }
+
+    return CMT_FALSE;
+}
+
+static int filter_context_fqname(struct cmt *dst, struct cmt *src,
+                                 const char *fqname, int flags)
+{
+    int ret;
+    struct cfl_list *head;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_untyped *untyped;
+    struct cmt_histogram *histogram;
+    struct cmt_summary *summary;
+
+     /* Counters */
+    cfl_list_foreach(head, &src->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+
+        if (compare_fqname(counter->map->opts, fqname, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_counter(dst, counter);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Gauges */
+    cfl_list_foreach(head, &src->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+        if (compare_fqname(gauge->map->opts, fqname, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_gauge(dst, gauge);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Untyped */
+    cfl_list_foreach(head, &src->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+        if (compare_fqname(untyped->map->opts, fqname, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_untyped(dst, untyped);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Histogram */
+    cfl_list_foreach(head, &src->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+        if (compare_fqname(histogram->map->opts, fqname, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_histogram(dst, histogram);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    /* Summary */
+    cfl_list_foreach(head, &src->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+        if (compare_fqname(summary->map->opts, fqname, flags) == CMT_FALSE) {
+            continue;
+        }
+
+        ret = cmt_cat_copy_summary(dst, summary);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    return CMT_FILTER_SUCCESS;
+}
+
+int cmt_filter(struct cmt *dst, struct cmt *src,
+               const char *fqname, const char *label_key,
+               int flags)
+{
+    int ret = CMT_FILTER_SUCCESS;
+
+    if (!dst) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (!src) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if ((flags & CMT_FILTER_PREFIX) &&
+        (flags & CMT_FILTER_SUBSTRING)) {
+        return CMT_FILTER_INVALID_FLAGS;
+    }
+
+    if (fqname != NULL) {
+        ret = filter_context_fqname(dst, src, fqname, flags);
+    }
+
+    if (ret != CMT_FILTER_SUCCESS) {
+        return CMT_FILTER_FAILED_OPERATION;
+    }
+
+    if (label_key != NULL) {
+        ret = filter_context_label_key(dst, src, label_key, flags);
+    }
+
+    if (ret != CMT_FILTER_SUCCESS) {
+        return CMT_FILTER_FAILED_OPERATION;
+    }
+
+    return ret;
+}

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -33,12 +33,17 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
 {
     struct cfl_list *head;
     struct cmt_map_label *label;
+    size_t label_key_size = 0;
+
+    if (label_key != NULL) {
+        label_key_size = strlen(label_key);
+    }
 
     cfl_list_foreach(head, &src->label_keys) {
         label = cfl_list_entry(head, struct cmt_map_label, _head);
         /* compare label_keys for prefix */
         if (flags & CMT_FILTER_PREFIX) {
-            if (strncmp(label->name, label_key, strlen(label_key)) == 0) {
+            if (strncmp(label->name, label_key, label_key_size) == 0) {
                 return (flags & CMT_FILTER_EXCLUDE) ? CMT_FALSE : CMT_TRUE;
             }
 
@@ -54,7 +59,11 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
             return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
         }
 
-        /* compare with an external context (e.g. Onigmo) */
+        /* Compare with an external context (e.g. Onigmo).
+         * flb_regex_match should take three arguments that are
+         * flb_regex context, string and its string length.
+         * The length of string is changed and not determined by label_key.
+         */
         if (compare_ctx != NULL && compare != NULL) {
             return compare(compare_ctx, label->name, strlen(label->name));
         }
@@ -171,7 +180,11 @@ static int compare_fqname(struct cmt_opts *src, const char *fqname,
         return (flags & CMT_FILTER_EXCLUDE) ? CMT_TRUE : CMT_FALSE;
     }
 
-    /* compare with an external context (e.g. Onigmo) */
+    /* Compare with an external context (e.g. Onigmo).
+     * flb_regex_match should take three arguments that are
+     * flb_regex context, string and its string length.
+     * The length of string is changed and not determined by fqname.
+     */
     if (compare_ctx != NULL && compare != NULL) {
         return compare(compare_ctx, src->fqname, strlen(src->fqname));
     }

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -289,7 +289,9 @@ int cmt_filter(struct cmt *dst, struct cmt *src,
         return CMT_FILTER_FAILED_OPERATION;
     }
 
-    if (label_key != NULL || (compare_ctx != NULL && compare != NULL)) {
+    /* On callback mode, labels are not searched by default. */
+    if (label_key != NULL ||
+        (compare_ctx != NULL && compare != NULL && flags & CMT_FILTER_REGEX_SEARCH_LABELS)) {
         ret = filter_context_label_key(dst, src, label_key, compare_ctx, compare, flags);
     }
 

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -37,6 +37,8 @@ static int compare_label_keys(struct cmt_map *src, const char *label_key,
 
     if (flags & CMT_FILTER_PREFIX && label_key != NULL) {
         label_key_size = strlen(label_key);
+
+        return CMT_FALSE;
     }
 
     cfl_list_foreach(head, &src->label_keys) {

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -93,7 +93,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter);
         if (ret == -1) {
             return -1;
         }
@@ -107,7 +107,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge);
         if (ret == -1) {
             return -1;
         }
@@ -121,7 +121,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped);
         if (ret == -1) {
             return -1;
         }
@@ -135,7 +135,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram);
         if (ret == -1) {
             return -1;
         }
@@ -149,7 +149,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary);
         if (ret == -1) {
             return -1;
         }
@@ -213,7 +213,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter);
         if (ret == -1) {
             return -1;
         }
@@ -226,7 +226,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge);
         if (ret == -1) {
             return -1;
         }
@@ -239,7 +239,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped);
         if (ret == -1) {
             return -1;
         }
@@ -252,7 +252,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram);
         if (ret == -1) {
             return -1;
         }
@@ -265,7 +265,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_copy_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary);
         if (ret == -1) {
             return -1;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TESTS_FILES
   cat.c
   issues.c
   null_label.c
+  filter.c
   )
 
 if (CMT_BUILD_PROMETHEUS_DECODER)

--- a/tests/filter.c
+++ b/tests/filter.c
@@ -207,7 +207,8 @@ void test_filter()
     /* filter with fqname (INCLUDE & PREFIX) */
     fqname = "spring";
     flags |= CMT_FILTER_PREFIX;
-    ret = cmt_filter(cmt2, cmt, fqname, NULL, flags);
+    ret = cmt_filter(cmt2, cmt, fqname, NULL,
+                     NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (fqname) */
@@ -225,7 +226,8 @@ void test_filter()
     /* filter with fqname (INCLUDE & SUBSTRING) */
     fqname = "load";
     flags |= CMT_FILTER_SUBSTRING;
-    ret = cmt_filter(cmt3, cmt, fqname, NULL, flags);
+    ret = cmt_filter(cmt3, cmt, fqname, NULL,
+                     NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (fqname) */
@@ -243,7 +245,8 @@ void test_filter()
     /* filter with label_key (EXCLUDE & PREFIX) */
     label_key = "host";
     flags |= CMT_FILTER_PREFIX;
-    ret = cmt_filter(cmt4, cmt, NULL, label_key, flags);
+    ret = cmt_filter(cmt4, cmt, NULL, label_key,
+                     NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (label_key) */
@@ -262,7 +265,8 @@ void test_filter()
     label_key = "label";
     flags |= CMT_FILTER_EXCLUDE;
     flags |= CMT_FILTER_SUBSTRING;
-    ret = cmt_filter(cmt5, cmt, NULL, label_key, flags);
+    ret = cmt_filter(cmt5, cmt, NULL, label_key,
+                     NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (label_key) */

--- a/tests/filter.c
+++ b/tests/filter.c
@@ -195,27 +195,30 @@ void test_filter()
     struct cmt *cmt3;
     struct cmt *cmt4;
     struct cmt *cmt5;
+    struct cmt *cmt6;
     int flags = 0;
     char *fqname;
     char *label_key;
 
     cmt = generate_filter_test_data();
 
+    text = cmt_encode_text_create(cmt);
+    printf("[Not filtered] ====>\n%s\n", text);
+
+    cmt_encode_text_destroy(text);
+
     cmt2 = cmt_create();
     TEST_CHECK(cmt2 != NULL);
 
-    /* filter with fqname (INCLUDE & PREFIX) */
-    fqname = "spring";
-    flags |= CMT_FILTER_PREFIX;
+    /* filter with fqname (SUBSTRING) */
+    fqname = "counter";
+    flags |= CMT_FILTER_SUBSTRING;
     ret = cmt_filter(cmt2, cmt, fqname, NULL,
                      NULL, NULL, flags);
     TEST_CHECK(ret == 0);
-
     /* check output (fqname) */
     text = cmt_encode_text_create(cmt2);
-    printf("====>\n%s\n", text);
-
-    cmt_encode_text_destroy(text);
+    printf("[substring matched with \"%s\" in fqname] ====>\n%s\n", fqname, text);
 
     /* reset flags */
     flags = 0;
@@ -223,35 +226,35 @@ void test_filter()
     cmt3 = cmt_create();
     TEST_CHECK(cmt3 != NULL);
 
-    /* filter with fqname (INCLUDE & SUBSTRING) */
-    fqname = "load";
-    flags |= CMT_FILTER_SUBSTRING;
+    /* filter with fqname (INCLUDE & PREFIX) */
+    fqname = "spring";
+    flags |= CMT_FILTER_PREFIX;
     ret = cmt_filter(cmt3, cmt, fqname, NULL,
                      NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (fqname) */
     text = cmt_encode_text_create(cmt3);
-    printf("====>\n%s\n", text);
+    printf("[prefix matched with \"%s\" in fqname] ====>\n%s\n", fqname, text);
 
     cmt_encode_text_destroy(text);
-
-    cmt4 = cmt_create();
-    TEST_CHECK(cmt4 != NULL);
 
     /* reset flags */
     flags = 0;
 
-    /* filter with label_key (EXCLUDE & PREFIX) */
-    label_key = "host";
-    flags |= CMT_FILTER_PREFIX;
-    ret = cmt_filter(cmt4, cmt, NULL, label_key,
+    cmt4 = cmt_create();
+    TEST_CHECK(cmt4 != NULL);
+
+    /* filter with fqname (INCLUDE & SUBSTRING) */
+    fqname = "load";
+    flags |= CMT_FILTER_SUBSTRING;
+    ret = cmt_filter(cmt4, cmt, fqname, NULL,
                      NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
-    /* check output (label_key) */
+    /* check output (fqname) */
     text = cmt_encode_text_create(cmt4);
-    printf("====>\n%s\n", text);
+    printf("[substring matched with \"%s\" in fqname] ====>\n%s\n", fqname, text);
 
     cmt_encode_text_destroy(text);
 
@@ -261,17 +264,36 @@ void test_filter()
     /* reset flags */
     flags = 0;
 
-    /* filter with label_key (EXCLUDE & SUBSTRING) */
-    label_key = "label";
-    flags |= CMT_FILTER_EXCLUDE;
-    flags |= CMT_FILTER_SUBSTRING;
+    /* filter with label_key (EXCLUDE & PREFIX) */
+    label_key = "host";
+    flags |= CMT_FILTER_PREFIX;
     ret = cmt_filter(cmt5, cmt, NULL, label_key,
                      NULL, NULL, flags);
     TEST_CHECK(ret == 0);
 
     /* check output (label_key) */
     text = cmt_encode_text_create(cmt5);
-    printf("====>\n%s\n", text);
+    printf("[prefix matched with \"%s\" in label key] ====>\n%s\n", label_key, text);
+
+    cmt_encode_text_destroy(text);
+
+    cmt6 = cmt_create();
+    TEST_CHECK(cmt6 != NULL);
+
+    /* reset flags */
+    flags = 0;
+
+    /* filter with label_key (EXCLUDE & SUBSTRING) */
+    label_key = "label";
+    flags |= CMT_FILTER_EXCLUDE;
+    flags |= CMT_FILTER_SUBSTRING;
+    ret = cmt_filter(cmt6, cmt, NULL, label_key,
+                     NULL, NULL, flags);
+    TEST_CHECK(ret == 0);
+
+    /* check output (label_key) */
+    text = cmt_encode_text_create(cmt6);
+    printf("[exclude with \"%s\" in label key] ====>\n%s\n", label_key, text);
 
     cmt_encode_text_destroy(text);
 
@@ -281,6 +303,7 @@ void test_filter()
     cmt_destroy(cmt3);
     cmt_destroy(cmt4);
     cmt_destroy(cmt5);
+    cmt_destroy(cmt6);
 }
 
 TEST_LIST = {

--- a/tests/filter.c
+++ b/tests/filter.c
@@ -1,0 +1,285 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021-2024 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_untyped.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_encode_text.h>
+#include <cmetrics/cmt_filter.h>
+
+#include "cmt_tests.h"
+
+/* values to observe in a histogram */
+double hist_observe_values[10] = {
+                                  0.0 , 1.02, 2.04, 3.06,
+                                  4.08, 5.10, 6.12, 7.14,
+                                  8.16, 9.18
+                                 };
+
+/*
+ * histogram bucket values: the values computed in the buckets,
+ * all of them are uint64_t.
+ *
+ * Note that on all examples we use the default buckets values, created manually
+ * and through the API:
+ *
+ * - 11 bucket values
+ * -  1 +Inf bucket value
+ */
+uint64_t hist_buckets_values[12] = {1, 1, 1, 1, 1, 1, 1, 1,
+                                    3, 5, 10, 10};
+/* histogram _count value */
+uint64_t hist_count = 10;
+
+/* histogram _sum value */
+double hist_sum = 45.9;
+
+struct cmt *generate_filter_test_data()
+{
+    int i;
+    struct cmt *cmt;
+    uint64_t val;
+    uint64_t ts;
+    double sum;
+    uint64_t count;
+    double q[6];
+    double r[6];
+
+    struct cmt_counter *c;
+    struct cmt_gauge *g;
+    struct cmt_untyped *u;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+    struct cmt_summary *s;
+
+    /* cmetrics */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    c = cmt_counter_create(cmt, "cmetrics", "test", "cat_counter", "first counter",
+                           2, (char *[]) {"label1", "label2"});
+    TEST_CHECK(c != NULL);
+
+    g = cmt_gauge_create(cmt, "cmetrics", "test", "cat_gauge", "first gauge",
+                         2, (char *[]) {"label3", "label4"});
+    TEST_CHECK(g != NULL);
+
+    u = cmt_untyped_create(cmt, "cmetrics", "test", "cat_untyped", "first untyped",
+                           2, (char *[]) {"hostname", "net"});
+    TEST_CHECK(u != NULL);
+
+
+    ts = cfl_time_now();
+    cmt_counter_set(c, ts, 1.1, 2, (char *[]) {"aaa", "bbb"});
+
+    ts = cfl_time_now();
+    cmt_gauge_set(g, ts, 1.2, 2, (char *[]) {"yyy", "xxx"});
+
+    ts = cfl_time_now();
+    cmt_untyped_set(u, ts, 1.3, 2, (char *[]) {"localhost", "eth0"});
+
+    c = cmt_counter_create(cmt, "cmetrics", "test", "cat_counter", "second counter",
+                           2, (char *[]) {"label1", "label2"});
+    TEST_CHECK(c != NULL);
+
+    g = cmt_gauge_create(cmt, "cmetrics", "test", "cat_gauge", "second gauge",
+                         2, (char *[]) {"label3", "label4"});
+    TEST_CHECK(g != NULL);
+
+    ts = cfl_time_now();
+    cmt_counter_set(c, ts, 2.1, 2, (char *[]) {"ccc", "ddd"});
+
+    /* no labels */
+    cmt_counter_set(c, ts, 5, 0, NULL);
+
+    ts = cfl_time_now();
+    cmt_gauge_add(g, ts, 10, 2, (char *[]) {"tyu", "iop"});
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(11,
+                                           0.005, 0.01, 0.025, 0.05,
+                                           0.1, 0.25, 0.5, 1.0, 2.5,
+                                           5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a histogram metric type */
+    h = cmt_histogram_create(cmt,
+                             "k8s", "network", "load", "Network load",
+                             buckets,
+                             1, (char *[]) {"my_label"});
+    TEST_CHECK(h != NULL);
+
+    ts = cfl_time_now();
+    for (i = 0; i < sizeof(hist_observe_values)/(sizeof(double)); i++) {
+        val = hist_observe_values[i];
+        cmt_histogram_observe(h, ts, val, 1, (char *[]) {"my_label"});
+    }
+
+    ts = cfl_time_now();
+
+    /* set quantiles */
+    q[0] = 0.1;
+    q[1] = 0.2;
+    q[2] = 0.3;
+    q[3] = 0.4;
+    q[4] = 0.5;
+    q[5] = 1.0;
+
+    r[0] = 1;
+    r[1] = 2;
+    r[2] = 3;
+    r[3] = 4;
+    r[4] = 5;
+    r[5] = 6;
+
+    /* Create a gauge metric type */
+    s = cmt_summary_create(cmt,
+                           "spring", "kafka_listener", "seconds", "Kafka Listener Timer",
+                           6, q,
+                           3, (char *[]) {"exception", "name", "result"});
+    TEST_CHECK(s != NULL);
+
+    /* no quantiles, labels */
+    sum = 0.0;
+    count = 1;
+
+    cmt_summary_set_default(s, ts, NULL, sum, count,
+                            3, (char *[]) {"ListenerExecutionFailedException",
+                                           "org.springframework.kafka.KafkaListenerEndpointContainer#0-0",
+                                           "failure"});
+
+    /* no quantiles, labels */
+    sum = 0.1;
+    count = 2;
+    cmt_summary_set_default(s, ts, NULL, sum, count,
+                            3, (char *[]) {"none",
+                                          "org.springframework.kafka.KafkaListenerEndpointContainer#0-0",
+                                          "success"});
+
+    /* quantiles, labels */
+    sum = 0.2;
+    count = 3;
+    cmt_summary_set_default(s, ts, r, sum, count,
+                            3, (char *[]) {"extra test",
+                                           "org.springframework.kafka.KafkaListenerEndpointContainer#0-0",
+                                           "success"});
+
+    return cmt;
+}
+
+void test_filter()
+{
+    int ret;
+    cfl_sds_t text;
+    struct cmt *cmt;
+    struct cmt *cmt2;
+    struct cmt *cmt3;
+    struct cmt *cmt4;
+    struct cmt *cmt5;
+    int flags = 0;
+    char *fqname;
+    char *label_key;
+
+    cmt = generate_filter_test_data();
+
+    cmt2 = cmt_create();
+    TEST_CHECK(cmt2 != NULL);
+
+    /* filter with fqname (INCLUDE & PREFIX) */
+    fqname = "spring";
+    flags |= CMT_FILTER_PREFIX;
+    ret = cmt_filter(cmt2, cmt, fqname, NULL, flags);
+    TEST_CHECK(ret == 0);
+
+    /* check output (fqname) */
+    text = cmt_encode_text_create(cmt2);
+    printf("====>\n%s\n", text);
+
+    cmt_encode_text_destroy(text);
+
+    /* reset flags */
+    flags = 0;
+
+    cmt3 = cmt_create();
+    TEST_CHECK(cmt3 != NULL);
+
+    /* filter with fqname (INCLUDE & SUBSTRING) */
+    fqname = "load";
+    flags |= CMT_FILTER_SUBSTRING;
+    ret = cmt_filter(cmt3, cmt, fqname, NULL, flags);
+    TEST_CHECK(ret == 0);
+
+    /* check output (fqname) */
+    text = cmt_encode_text_create(cmt3);
+    printf("====>\n%s\n", text);
+
+    cmt_encode_text_destroy(text);
+
+    cmt4 = cmt_create();
+    TEST_CHECK(cmt4 != NULL);
+
+    /* reset flags */
+    flags = 0;
+
+    /* filter with label_key (EXCLUDE & PREFIX) */
+    label_key = "host";
+    flags |= CMT_FILTER_PREFIX;
+    ret = cmt_filter(cmt4, cmt, NULL, label_key, flags);
+    TEST_CHECK(ret == 0);
+
+    /* check output (label_key) */
+    text = cmt_encode_text_create(cmt4);
+    printf("====>\n%s\n", text);
+
+    cmt_encode_text_destroy(text);
+
+    cmt5 = cmt_create();
+    TEST_CHECK(cmt5 != NULL);
+
+    /* reset flags */
+    flags = 0;
+
+    /* filter with label_key (EXCLUDE & SUBSTRING) */
+    label_key = "label";
+    flags |= CMT_FILTER_EXCLUDE;
+    flags |= CMT_FILTER_SUBSTRING;
+    ret = cmt_filter(cmt5, cmt, NULL, label_key, flags);
+    TEST_CHECK(ret == 0);
+
+    /* check output (label_key) */
+    text = cmt_encode_text_create(cmt5);
+    printf("====>\n%s\n", text);
+
+    cmt_encode_text_destroy(text);
+
+    /* destroy contexts */
+    cmt_destroy(cmt);
+    cmt_destroy(cmt2);
+    cmt_destroy(cmt3);
+    cmt_destroy(cmt4);
+    cmt_destroy(cmt5);
+}
+
+TEST_LIST = {
+    {"filter", test_filter},
+    { 0 }
+};

--- a/tests/filter.c
+++ b/tests/filter.c
@@ -220,6 +220,8 @@ void test_filter()
     text = cmt_encode_text_create(cmt2);
     printf("[substring matched with \"%s\" in fqname] ====>\n%s\n", fqname, text);
 
+    cmt_encode_text_destroy(text);
+
     /* reset flags */
     flags = 0;
 


### PR DESCRIPTION
I implemented filtering mechanism which is mainly targeted for full qualified name of metrics (fqname).
Maybe, we need to implement filtering mechanism for label values but traversing values of labels are more complex rather than just searching with keys of labels.
Also, cmetrics should provide a capability to inject external callback function which uses Onigmo contexts that are mainly used in filter_grep or perhaps processor_grep?