### PR TITLE
filter: Implement deleting by label key-value pair operation

### DIFF
--- a/include/cmetrics/cmt_cat.h
+++ b/include/cmetrics/cmt_cat.h
@@ -29,11 +29,11 @@ struct cmt_histogram;
 struct cmt_summary;
 
 int cmt_cat_copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *src);
-int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter);
-int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge);
-int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped);
-int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram);
-int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary);
+int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter, struct cmt_map *filtered_map);
+int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge, struct cmt_map *filtered_map);
+int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped, struct cmt_map *filtered_map);
+int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram, struct cmt_map *filtered_map);
+int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary, struct cmt_map *filtered_map);
 int cmt_cat(struct cmt *dst, struct cmt *src);
 
 #endif

--- a/include/cmetrics/cmt_cat.h
+++ b/include/cmetrics/cmt_cat.h
@@ -28,6 +28,7 @@ struct cmt_untyped;
 struct cmt_histogram;
 struct cmt_summary;
 
+int cmt_cat_copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *src);
 int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter);
 int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge);
 int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped);

--- a/include/cmetrics/cmt_cat.h
+++ b/include/cmetrics/cmt_cat.h
@@ -28,6 +28,7 @@ struct cmt_untyped;
 struct cmt_histogram;
 struct cmt_summary;
 
+int cmt_cat_copy_label_keys(struct cmt_map *map, char **out);
 int cmt_cat_copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *src);
 int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter, struct cmt_map *filtered_map);
 int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge, struct cmt_map *filtered_map);

--- a/include/cmetrics/cmt_filter.h
+++ b/include/cmetrics/cmt_filter.h
@@ -38,4 +38,8 @@ int cmt_filter(struct cmt *dst, struct cmt *src,
                void *compare_ctx, int (*compare)(void *compare_ctx, const char *str, size_t slen),
                int flags);
 
+int cmt_filter_with_label_pair(struct cmt *dst, struct cmt *src,
+                               const char *label_key,
+                               const char *label_value);
+
 #endif

--- a/include/cmetrics/cmt_map.h
+++ b/include/cmetrics/cmt_map.h
@@ -55,6 +55,7 @@ struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map
 int cmt_map_metric_get_val(struct cmt_opts *opts, struct cmt_map *map,
                            int labels_count, char **labels_val,
                            double *out_val);
+void cmt_map_metric_destroy(struct cmt_metric *metric);
 
 void destroy_label_list(struct cfl_list *label_list);
 

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -26,7 +26,7 @@
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_summary.h>
 
-static int copy_label_keys(struct cmt_map *map, char **out)
+int cmt_cat_copy_label_keys(struct cmt_map *map, char **out)
 {
     int i;
     int s;
@@ -225,7 +225,7 @@ int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter,
     map = counter->map;
     opts = map->opts;
 
-    ret = copy_label_keys(map, (char **) &labels);
+    ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }
@@ -269,7 +269,7 @@ int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge,
     map = gauge->map;
     opts = map->opts;
 
-    ret = copy_label_keys(map, (char **) &labels);
+    ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }
@@ -312,7 +312,7 @@ int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped,
     map = untyped->map;
     opts = map->opts;
 
-    ret = copy_label_keys(map, (char **) &labels);
+    ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }
@@ -361,7 +361,7 @@ int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram,
     opts = map->opts;
     timestamp = cmt_metric_get_timestamp(&map->metric);
 
-    ret = copy_label_keys(map, (char **) &labels);
+    ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }
@@ -415,7 +415,7 @@ int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary,
     opts = map->opts;
     timestamp = cmt_metric_get_timestamp(&map->metric);
 
-    ret = copy_label_keys(map, (char **) &labels);
+    ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -96,7 +96,7 @@ static int copy_label_values(struct cmt_metric *metric, char **out)
     return i;
 }
 
-static int copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *src)
+int cmt_cat_copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map *src)
 {
     int i;
     int c;
@@ -240,7 +240,7 @@ int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter)
         return -1;
     }
 
-    ret = copy_map(&c->opts, c->map, map);
+    ret = cmt_cat_copy_map(&c->opts, c->map, map);
     if (ret == -1) {
         return -1;
     }
@@ -274,7 +274,7 @@ int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
         return -1;
     }
 
-    ret = copy_map(&g->opts, g->map, map);
+    ret = cmt_cat_copy_map(&g->opts, g->map, map);
     if (ret == -1) {
         return -1;
     }
@@ -308,7 +308,7 @@ int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
         return -1;
     }
 
-    ret = copy_map(&u->opts, u->map, map);
+    ret = cmt_cat_copy_map(&u->opts, u->map, map);
     if (ret == -1) {
         return -1;
     }
@@ -354,7 +354,7 @@ int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
         return -1;
     }
 
-    ret = copy_map(&hist->opts, hist->map, map);
+    ret = cmt_cat_copy_map(&hist->opts, hist->map, map);
     if (ret == -1) {
         return -1;
     }
@@ -405,7 +405,7 @@ int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary)
     free(labels);
     free(quantiles);
 
-    ret = copy_map(&sum->opts, sum->map, map);
+    ret = cmt_cat_copy_map(&sum->opts, sum->map, map);
     if (ret == -1) {
         return -1;
     }

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -213,7 +213,8 @@ int cmt_cat_copy_map(struct cmt_opts *opts, struct cmt_map *dst, struct cmt_map 
 
 }
 
-int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter)
+int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter,
+                    struct cmt_map *filtered_map)
 {
     int ret;
     char **labels = NULL;
@@ -240,15 +241,24 @@ int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter)
         return -1;
     }
 
-    ret = cmt_cat_copy_map(&c->opts, c->map, map);
-    if (ret == -1) {
-        return -1;
+    if (filtered_map != NULL) {
+        ret = cmt_cat_copy_map(&c->opts, c->map, filtered_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else {
+        ret = cmt_cat_copy_map(&c->opts, c->map, map);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;
 }
 
-int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
+int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge,
+                  struct cmt_map *filtered_map)
 {
     int ret;
     char **labels = NULL;
@@ -274,15 +284,24 @@ int cmt_cat_gauge(struct cmt *cmt, struct cmt_gauge *gauge)
         return -1;
     }
 
-    ret = cmt_cat_copy_map(&g->opts, g->map, map);
-    if (ret == -1) {
-        return -1;
+    if (filtered_map != NULL) {
+        ret = cmt_cat_copy_map(&g->opts, g->map, filtered_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else {
+        ret = cmt_cat_copy_map(&g->opts, g->map, map);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;
 }
 
-int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
+int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped,
+                    struct cmt_map *filtered_map)
 {
     int ret;
     char **labels = NULL;
@@ -308,15 +327,24 @@ int cmt_cat_untyped(struct cmt *cmt, struct cmt_untyped *untyped)
         return -1;
     }
 
-    ret = cmt_cat_copy_map(&u->opts, u->map, map);
-    if (ret == -1) {
-        return -1;
+    if (filtered_map != NULL) {
+        ret = cmt_cat_copy_map(&u->opts, u->map, filtered_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else {
+        ret = cmt_cat_copy_map(&u->opts, u->map, map);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;
 }
 
-int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
+int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram,
+                      struct cmt_map *filtered_map)
 {
     int i;
     double val;
@@ -354,15 +382,24 @@ int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram)
         return -1;
     }
 
-    ret = cmt_cat_copy_map(&hist->opts, hist->map, map);
-    if (ret == -1) {
-        return -1;
+    if (filtered_map != NULL) {
+        ret = cmt_cat_copy_map(&hist->opts, hist->map, filtered_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else {
+        ret = cmt_cat_copy_map(&hist->opts, hist->map, map);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;
 }
 
-int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary)
+int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary,
+                    struct cmt_map *filtered_map)
 {
     int i;
     int ret;
@@ -405,9 +442,17 @@ int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary)
     free(labels);
     free(quantiles);
 
-    ret = cmt_cat_copy_map(&sum->opts, sum->map, map);
-    if (ret == -1) {
-        return -1;
+    if (filtered_map != NULL) {
+        ret = cmt_cat_copy_map(&sum->opts, sum->map, filtered_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else {
+        ret = cmt_cat_copy_map(&sum->opts, sum->map, map);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;
@@ -426,7 +471,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
      /* Counters */
     cfl_list_foreach(head, &src->counters) {
         counter = cfl_list_entry(head, struct cmt_counter, _head);
-        ret = cmt_cat_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -435,7 +480,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Gauges */
     cfl_list_foreach(head, &src->gauges) {
         gauge = cfl_list_entry(head, struct cmt_gauge, _head);
-        ret = cmt_cat_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -444,7 +489,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Untyped */
     cfl_list_foreach(head, &src->untypeds) {
         untyped = cfl_list_entry(head, struct cmt_untyped, _head);
-        ret = cmt_cat_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -453,7 +498,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Histogram */
     cfl_list_foreach(head, &src->histograms) {
         histogram = cfl_list_entry(head, struct cmt_histogram, _head);
-        ret = cmt_cat_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -462,7 +507,7 @@ static int append_context(struct cmt *dst, struct cmt *src)
     /* Summary */
     cfl_list_foreach(head, &src->summaries) {
         summary = cfl_list_entry(head, struct cmt_summary, _head);
-        ret = cmt_cat_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary, NULL);
         if (ret == -1) {
             return -1;
         }

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -162,6 +162,300 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
     return CMT_FILTER_SUCCESS;
 }
 
+static int filter_get_label_index(struct cmt_map *src, const char *label_key)
+{
+    struct cfl_list *head;
+    struct cmt_map_label *label;
+    size_t index = 0;
+
+    cfl_list_foreach(head, &src->label_keys) {
+        label = cfl_list_entry(head, struct cmt_map_label, _head);
+        if (strcasecmp(label->name, label_key) == 0) {
+           return index;
+        }
+
+        index++;
+    }
+
+    return -1;
+}
+
+int metrics_check_label_value_existence(struct cmt_metric *metric,
+                                        size_t label_index,
+                                        const char *label_value)
+{
+    struct cfl_list      *iterator;
+    size_t                index;
+    struct cmt_map_label *label = NULL;
+
+    index = 0;
+
+    cfl_list_foreach(iterator, &metric->labels) {
+        label = cfl_list_entry(iterator, struct cmt_map_label, _head);
+
+        if (label_index == index) {
+            break;
+        }
+
+        index++;
+    }
+
+    if (label_index != index) {
+        return CMT_FALSE;
+    }
+
+    if (label == NULL) {
+        return CMT_FALSE;
+    }
+
+    if (label->name == NULL) {
+        return CMT_FALSE;
+    }
+
+    if (strncasecmp(label->name, label_value, strlen(label->name)) == 0) {
+        return CMT_TRUE;
+    }
+
+    return CMT_FALSE;
+}
+
+static int metrics_map_drop_label_value_pairs(struct cmt_map *map,
+                                              size_t label_index,
+                                              const char *label_value)
+{
+    struct cfl_list   *head;
+    struct cmt_metric *metric;
+    int                result;
+
+    result = CMT_FALSE;
+
+    cfl_list_foreach(head, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+
+        result = metrics_check_label_value_existence(metric,
+                                                     label_index,
+                                                     label_value);
+
+        if (result == CMT_TRUE) {
+            result = CMT_TRUE;
+            break;
+        }
+    }
+
+    if (result == CMT_TRUE) {
+        cmt_map_metric_destroy(metric);
+    }
+
+    return result;
+}
+
+static int filter_context_label_key_value(struct cmt *dst, struct cmt *src,
+                                          const char *label_key, const char *label_value)
+{
+    int ret;
+    char **labels = NULL;
+    struct cfl_list *head;
+    struct cmt_map *map;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_untyped *untyped;
+    struct cmt_histogram *histogram;
+    struct cmt_summary *summary;
+    size_t index = 0;
+
+     /* Counters */
+    cfl_list_foreach(head, &src->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+
+        ret = cmt_cat_copy_label_keys(counter->map, (char **) &labels);
+        if (ret == -1) {
+            return -1;
+        }
+
+        map = cmt_map_create(CMT_COUNTER, &counter->opts,
+                             counter->map->label_count,
+                             labels, (void *) counter);
+        free(labels);
+        if (!map) {
+            cmt_log_error(src, "unable to allocate map for counter");
+            return -1;
+        }
+
+        ret = cmt_cat_copy_map(&counter->opts, map, counter->map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        index = filter_get_label_index(map, label_key);
+        if (index != -1) {
+            metrics_map_drop_label_value_pairs(map, index, label_value);
+        }
+
+        ret = cmt_cat_counter(dst, counter, map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        cmt_map_destroy(map);
+    }
+
+    /* Gauges */
+    cfl_list_foreach(head, &src->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+
+        ret = cmt_cat_copy_label_keys(gauge->map, (char **) &labels);
+        if (ret == -1) {
+            return -1;
+        }
+
+        map = cmt_map_create(CMT_GAUGE, &gauge->opts,
+                             gauge->map->label_count,
+                             labels, (void *) gauge);
+        free(labels);
+        if (!map) {
+            cmt_log_error(src, "unable to allocate map for gauge");
+            return -1;
+        }
+
+        ret = cmt_cat_copy_map(&gauge->opts, map, gauge->map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        index = filter_get_label_index(map, label_key);
+        if (index != -1) {
+            metrics_map_drop_label_value_pairs(map, index, label_value);
+        }
+
+        ret = cmt_cat_gauge(dst, gauge, map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        cmt_map_destroy(map);
+    }
+
+    /* Untyped */
+    cfl_list_foreach(head, &src->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+
+        ret = cmt_cat_copy_label_keys(untyped->map, (char **) &labels);
+        if (ret == -1) {
+            return -1;
+        }
+
+        map = cmt_map_create(CMT_UNTYPED, &gauge->opts,
+                             untyped->map->label_count,
+                             labels, (void *) untyped);
+        free(labels);
+        if (!map) {
+            cmt_log_error(src, "unable to allocate map for untyped");
+            return -1;
+        }
+
+        ret = cmt_cat_copy_map(&untyped->opts, map, untyped->map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        index = filter_get_label_index(map, label_key);
+        if (index != -1) {
+            metrics_map_drop_label_value_pairs(map, index, label_value);
+        }
+
+        ret = cmt_cat_untyped(dst, untyped, map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        cmt_map_destroy(map);
+    }
+
+    /* Histogram */
+    cfl_list_foreach(head, &src->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+
+        ret = cmt_cat_copy_label_keys(histogram->map, (char **) &labels);
+        if (ret == -1) {
+            return -1;
+        }
+
+        map = cmt_map_create(CMT_HISTOGRAM, &histogram->opts,
+                             histogram->map->label_count,
+                             labels, (void *) histogram);
+        free(labels);
+        if (!map) {
+            cmt_log_error(src, "unable to allocate map for histogram");
+            return -1;
+        }
+
+        ret = cmt_cat_copy_map(&histogram->opts, map, histogram->map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        index = filter_get_label_index(map, label_key);
+        if (index != -1) {
+            metrics_map_drop_label_value_pairs(map, index, label_value);
+        }
+
+        ret = cmt_cat_histogram(dst, histogram, map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        cmt_map_destroy(map);
+    }
+
+    /* Summary */
+    cfl_list_foreach(head, &src->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+
+        ret = cmt_cat_copy_label_keys(summary->map, (char **) &labels);
+        if (ret == -1) {
+            return -1;
+        }
+
+        map = cmt_map_create(CMT_SUMMARY, &summary->opts,
+                             summary->map->label_count,
+                             labels, (void *) summary);
+        free(labels);
+        if (!map) {
+            cmt_log_error(src, "unable to allocate map for summary");
+            return -1;
+        }
+
+        ret = cmt_cat_copy_map(&summary->opts, map, summary->map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        index = filter_get_label_index(map, label_key);
+        if (index != -1) {
+            metrics_map_drop_label_value_pairs(map, index, label_value);
+        }
+
+        ret = cmt_cat_summary(dst, summary, map);
+        if (ret == -1) {
+            cmt_map_destroy(map);
+            return -1;
+        }
+
+        cmt_map_destroy(map);
+    }
+
+    return CMT_FILTER_SUCCESS;
+}
+
 static int compare_fqname(struct cmt_opts *src, const char *fqname,
                           void *compare_ctx, int (*compare)(void *compare_ctx, const char *str, size_t slen),
                           int flags)
@@ -285,6 +579,39 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
     }
 
     return CMT_FILTER_SUCCESS;
+}
+
+int cmt_filter_with_label_pair(struct cmt *dst, struct cmt *src,
+                               const char *label_key,
+                               const char *label_value)
+{
+    int ret = CMT_FILTER_SUCCESS;
+
+    if (!dst) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (!src) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (label_key == NULL) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (label_value == NULL) {
+        return CMT_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (label_key != NULL && label_value != NULL) {
+        ret = filter_context_label_key_value(dst, src, label_key, label_value);
+    }
+
+    if (ret != CMT_FILTER_SUCCESS) {
+        return CMT_FILTER_FAILED_OPERATION;
+    }
+
+    return ret;
 }
 
 int cmt_filter(struct cmt *dst, struct cmt *src,

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -97,7 +97,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -111,7 +111,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -125,7 +125,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -139,7 +139,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -153,7 +153,7 @@ static int filter_context_label_key(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -226,7 +226,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_counter(dst, counter);
+        ret = cmt_cat_counter(dst, counter, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -239,7 +239,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_gauge(dst, gauge);
+        ret = cmt_cat_gauge(dst, gauge, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -252,7 +252,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_untyped(dst, untyped);
+        ret = cmt_cat_untyped(dst, untyped, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -265,7 +265,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_histogram(dst, histogram);
+        ret = cmt_cat_histogram(dst, histogram, NULL);
         if (ret == -1) {
             return -1;
         }
@@ -278,7 +278,7 @@ static int filter_context_fqname(struct cmt *dst, struct cmt *src,
             continue;
         }
 
-        ret = cmt_cat_summary(dst, summary);
+        ret = cmt_cat_summary(dst, summary, NULL);
         if (ret == -1) {
             return -1;
         }

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -170,7 +170,7 @@ static int filter_get_label_index(struct cmt_map *src, const char *label_key)
 
     cfl_list_foreach(head, &src->label_keys) {
         label = cfl_list_entry(head, struct cmt_map_label, _head);
-        if (strcasecmp(label->name, label_key) == 0) {
+        if (strncmp(label->name, label_key, strlen(label->name)) == 0) {
            return index;
         }
 
@@ -212,7 +212,7 @@ int metrics_check_label_value_existence(struct cmt_metric *metric,
         return CMT_FALSE;
     }
 
-    if (strncasecmp(label->name, label_value, strlen(label->name)) == 0) {
+    if (strncmp(label->name, label_value, strlen(label->name)) == 0) {
         return CMT_TRUE;
     }
 

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -136,7 +136,7 @@ static struct cmt_metric *map_metric_create(uint64_t hash,
     return NULL;
 }
 
-static void map_metric_destroy(struct cmt_metric *metric)
+void cmt_map_metric_destroy(struct cmt_metric *metric)
 {
     struct cfl_list *tmp;
     struct cfl_list *head;
@@ -270,7 +270,7 @@ void cmt_map_destroy(struct cmt_map *map)
 
     cfl_list_foreach_safe(head, tmp, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
-        map_metric_destroy(metric);
+        cmt_map_metric_destroy(metric);
     }
 
     /* histogram and quantile allocation for static metric */


### PR DESCRIPTION
Otel collector supports _delete by label value_ operation which means deleting metrics' data points by matched label key-value pair.

This patch makes to be able to handle label key-value based metrics deletions. And also it is intended to use processor_metrics_selector.