### PR TITLE
decode_prometheus: fix 64-bit timestamp parsing for Windows

### DIFF
--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -200,7 +200,7 @@ static int parse_uint64(const char *in, uint64_t *out)
     int64_t val;
 
     errno = 0;
-    val = strtol(in, &end, 10);
+    val = strtoll(in, &end, 10);
     if (end == in || *end != 0 || errno)  {
         return -1;
     }


### PR DESCRIPTION
This one's an absolute corker. Windows (even 64-bit!) uses an LLP64 data model where `long int` is still only 32-bits... so timestamp values in the Prometheus text exposition format (which are 64-bit ints by spec) greater than 2^32 do not get parsed correctly on Windows, because `strtol` parses to that 32-bit `long` :))) .

See: https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models .

On my 64-bit Linux, `int64_t` is `long`, but as best I can tell, casting `long long` to `long` is fine / a no-op there, given they are both 64-bit on that platform. If a more considered `sizeof(long long)` check is better I can do that instead but I figured it was probably overkill.