### PR TITLE
mpack_utils: Handle exdeeded limits of label values and replace with "..." for exceeded characters

### DIFF
--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -78,8 +78,7 @@ int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffe
 {
     uint32_t    string_length;
     mpack_tag_t tag;
-    cfl_sds_t   left_buffer;
-    uint32_t    left_length;
+    uint32_t    skip_length;
 
     if (NULL == output_buffer) {
         return CMT_MPACK_INVALID_ARGUMENT_ERROR;
@@ -113,18 +112,13 @@ int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffe
             return CMT_MPACK_ALLOCATION_ERROR;
         }
 
-        left_length = string_length - CMT_MPACK_MAX_STRING_LENGTH;
-        left_buffer = cfl_sds_create_size(left_length + 1);
-        if (NULL == left_buffer) {
-            return CMT_MPACK_ALLOCATION_ERROR;
-        }
+        skip_length = string_length - CMT_MPACK_MAX_STRING_LENGTH;
 
         cfl_sds_set_len(*output_buffer, CMT_MPACK_MAX_STRING_LENGTH);
         mpack_read_cstr(reader, *output_buffer, CMT_MPACK_MAX_STRING_LENGTH + 1, CMT_MPACK_MAX_STRING_LENGTH);
         cfl_sds_cat_safe(output_buffer, "...", 3);
 
-        mpack_read_cstr(reader, left_buffer, left_length + 1, left_length);
-        cfl_sds_destroy(left_buffer);
+        mpack_skip_bytes(reader, skip_length);
     }
     else {
         *output_buffer = cfl_sds_create_size(string_length + 1);

--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -78,6 +78,8 @@ int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffe
 {
     uint32_t    string_length;
     mpack_tag_t tag;
+    cfl_sds_t   left_buffer;
+    uint32_t    left_length;
 
     if (NULL == output_buffer) {
         return CMT_MPACK_INVALID_ARGUMENT_ERROR;
@@ -105,25 +107,35 @@ int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffe
      */
 
     if (CMT_MPACK_MAX_STRING_LENGTH < string_length) {
-        return CMT_MPACK_CORRUPT_INPUT_DATA_ERROR;
+        *output_buffer = cfl_sds_create_size(CMT_MPACK_MAX_STRING_LENGTH + 4);
+
+        if (NULL == *output_buffer) {
+            return CMT_MPACK_ALLOCATION_ERROR;
+        }
+
+        left_length = string_length - CMT_MPACK_MAX_STRING_LENGTH;
+        left_buffer = cfl_sds_create_size(left_length + 1);
+        if (NULL == left_buffer) {
+            return CMT_MPACK_ALLOCATION_ERROR;
+        }
+
+        cfl_sds_set_len(*output_buffer, CMT_MPACK_MAX_STRING_LENGTH);
+        mpack_read_cstr(reader, *output_buffer, CMT_MPACK_MAX_STRING_LENGTH + 1, CMT_MPACK_MAX_STRING_LENGTH);
+        cfl_sds_cat_safe(output_buffer, "...", 3);
+
+        mpack_read_cstr(reader, left_buffer, left_length + 1, left_length);
+        cfl_sds_destroy(left_buffer);
     }
+    else {
+        *output_buffer = cfl_sds_create_size(string_length + 1);
 
-    *output_buffer = cfl_sds_create_size(string_length + 1);
+        if (NULL == *output_buffer) {
+            return CMT_MPACK_ALLOCATION_ERROR;
+        }
 
-    if (NULL == *output_buffer) {
-        return CMT_MPACK_ALLOCATION_ERROR;
-    }
+        cfl_sds_set_len(*output_buffer, string_length);
 
-    cfl_sds_set_len(*output_buffer, string_length);
-
-    mpack_read_cstr(reader, *output_buffer, string_length + 1, string_length);
-
-    if (mpack_ok != mpack_reader_error(reader)) {
-        cfl_sds_destroy(*output_buffer);
-
-        *output_buffer = NULL;
-
-        return CMT_MPACK_ENGINE_ERROR;
+        mpack_read_cstr(reader, *output_buffer, string_length + 1, string_length);
     }
 
     mpack_done_str(reader);

--- a/tests/issues.c
+++ b/tests/issues.c
@@ -46,6 +46,29 @@ static struct cmt *generate_encoder_test_data()
     return cmt;
 }
 
+static struct cmt *generate_encoder_long_value_test_data()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_counter *c1;
+    struct cmt_counter *c2;
+    char long_value[1026];
+    memset(long_value, 'a', 1025);
+    long_value[1025] = '\0';
+
+    ts = 0;
+    cmt = cmt_create();
+
+    c1 = cmt_counter_create(cmt, "kubernetes", "", "load", "Network load",
+                            2, (char *[]) {"hostname", "app"});
+    cmt_counter_set(c1, ts, 10, 2, (char *[]){long_value, "issue"});
+
+    c2 = cmt_counter_create(cmt, "kubernetes", "", "cpu", "CPU load",
+                            2, (char *[]) {"hostname", "app"});
+    cmt_counter_set(c2, ts, 10, 2, (char *[]){long_value, "issue"});
+
+    return cmt;
+}
 
 void test_issue_54()
 {
@@ -89,7 +112,73 @@ void test_issue_54()
     cmt_destroy(cmt1);
 }
 
+void test_issue_fluent_bit_9297()
+{
+    const char  expected_text[] = \
+            "1970-01-01T00:00:00.000000000Z kubernetes_load{tag1=\"tag1\",tag2=\"tag2\",hostname=\"aaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaa...\",app=\"issue\"} = 10\n"                     \
+            "1970-01-01T00:00:00.000000000Z kubernetes_cpu{tag1=\"tag1\",tag2=\"tag2\",hostname=\"aaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+            "aaaaaaaaa...\",app=\"issue\"} = 10\n";
+    cfl_sds_t   text_result;
+    size_t      mp1_size;
+    char       *mp1_buf;
+    size_t      offset;
+    int         result;
+    struct cmt *cmt2;
+    struct cmt *cmt1;
+
+    cmt_initialize();
+
+    /* Generate context with data */
+    cmt1 = generate_encoder_long_value_test_data();
+    TEST_CHECK(NULL != cmt1);
+
+    /* append static labels */
+    cmt_label_add(cmt1, "tag1", "tag1");
+    cmt_label_add(cmt1, "tag2", "tag2");
+
+    /* CMT1 -> Msgpack */
+    result = cmt_encode_msgpack_create(cmt1, &mp1_buf, &mp1_size);
+    TEST_CHECK(0 == result);
+
+    /* Msgpack -> CMT2 */
+    offset = 0;
+    result = cmt_decode_msgpack_create(&cmt2, mp1_buf, mp1_size, &offset);
+    TEST_CHECK(0 == result);
+
+    text_result = cmt_encode_text_create(cmt2);
+
+    TEST_CHECK(NULL != text_result);
+    TEST_CHECK(0 == strcmp(text_result, expected_text));
+
+    cmt_encode_text_destroy(text_result);
+    cmt_decode_msgpack_destroy(cmt2);
+    cmt_encode_msgpack_destroy(mp1_buf);
+    cmt_destroy(cmt1);
+}
+
 TEST_LIST = {
     {"issue_54", test_issue_54},
+    {"issue_fluent_bit_9297", test_issue_fluent_bit_9297},
     { 0 }
 };


### PR DESCRIPTION
Currently, cmetrics just fails over 1024 bytes on labels of metrics.
I investigated this issue and found that cmetrics just returns as error when exceeding 1024 characters of value of labels.
Instead, we need to omit the exceeded bytes and replace with "..." on output stdout in fluent-bit. 

Related to https://github.com/fluent/fluent-bit/issues/9297