### PR TITLE
decode: msgpack: fix NULL dereference

### DIFF
--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -212,6 +212,26 @@ static int unpack_opts(mpack_reader_t *reader, struct cmt_opts *opts)
     result = cmt_mpack_unpack_map(reader, callbacks, (void *) opts);
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
+        /* Ensure required string fields are not NULL */
+        if (NULL == opts->ns) {
+            opts->ns = cfl_sds_create("");
+            if (NULL == opts->ns) {
+                return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+            }
+        }
+        if (NULL == opts->subsystem) {
+            opts->subsystem = cfl_sds_create("");
+            if (NULL == opts->subsystem) {
+                return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+            }
+        }
+        if (NULL == opts->name) {
+            opts->name = cfl_sds_create("");
+            if (NULL == opts->name) {
+                return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+            }
+        }
+
         /* Allocate enough space for the three components, the separators
          * and the terminator so we don't have to worry about possible realloc issues
          * later on.


### PR DESCRIPTION
Fixes the following issue detected by OSS-Fuzz:

- https://issues.oss-fuzz.com/issues/371659893

This fix was generated by CodeRover-S, an LLM agent for fixing security vulnerabilities. More details can be found at:

- https://arxiv.org/pdf/2411.03346
- https://github.com/AutoCodeRoverSG/auto-code-rover