### PR TITLE
cat: fix skipped +Inf in Histograms

### DIFF
--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -108,7 +108,7 @@ static inline int cat_histogram_values(struct cmt_metric *metric_dst, struct cmt
         }
     }
 
-    for (i = 0; i < histogram->buckets->count; i++) {
+    for (i = 0; i <= histogram->buckets->count; i++) {
         /* histogram buckets are always integers, no need to convert them */
         metric_dst->hist_buckets[i] += metric_src->hist_buckets[i];
     }

--- a/src/cmt_histogram.c
+++ b/src/cmt_histogram.c
@@ -36,7 +36,7 @@ struct cmt_histogram_buckets *cmt_histogram_buckets_create_size(double *bkts, si
     }
 
     /* besides buckets set by the user, we add an implicit bucket for +inf */
-    upper_bounds = calloc(1, sizeof(double) * count + 1);
+    upper_bounds = calloc(1, sizeof(double) * (count + 1));
     if (!upper_bounds) {
         cmt_errno();
         return NULL;


### PR DESCRIPTION
In addition to fix the conditional when iterating the buckets, add a little protection to the memory allocation size