### PR TITLE
cmetrics: add cmt_expire for expiring metrics.

### DIFF
--- a/include/cmetrics/cmetrics.h
+++ b/include/cmetrics/cmetrics.h
@@ -80,5 +80,6 @@ struct cmt *cmt_create();
 void cmt_destroy(struct cmt *cmt);
 int cmt_label_add(struct cmt *cmt, char *key, char *val);
 char *cmt_version();
+void cmt_expire(struct cmt *cmt, uint64_t expiration);
 
 #endif

--- a/include/cmetrics/cmt_map.h
+++ b/include/cmetrics/cmt_map.h
@@ -57,6 +57,9 @@ int cmt_map_metric_get_val(struct cmt_opts *opts, struct cmt_map *map,
                            double *out_val);
 void cmt_map_metric_destroy(struct cmt_metric *metric);
 
+int cmt_map_metrics_expire(struct cmt_map *, uint64_t);
+
 void destroy_label_list(struct cfl_list *label_list);
+
 
 #endif

--- a/include/cmetrics/cmt_map.h
+++ b/include/cmetrics/cmt_map.h
@@ -57,6 +57,9 @@ int cmt_map_metric_get_val(struct cmt_opts *opts, struct cmt_map *map,
                            double *out_val);
 void cmt_map_metric_destroy(struct cmt_metric *metric);
 
+void cmt_map_metrics_expire(struct cmt_map *, uint64_t);
+
 void destroy_label_list(struct cfl_list *label_list);
+
 
 #endif

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -172,7 +172,7 @@ void cmt_expire(struct cmt *cmt, uint64_t expiration)
 
     cfl_list_foreach_safe(head, tmp, &cmt->histograms) {
         h = cfl_list_entry(head, struct cmt_histogram, _head);
-        cmt_map_metrics_expire(s->map, expiration);
+        cmt_map_metrics_expire(h->map, expiration);
     }
 
     cfl_list_foreach_safe(head, tmp, &cmt->untypeds) {

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -30,6 +30,7 @@
 #include <cmetrics/cmt_atomic.h>
 #include <cmetrics/cmt_compat.h>
 #include <cmetrics/cmt_label.h>
+#include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_version.h>
 
 #include <cfl/cfl_kvlist.h>

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -30,6 +30,7 @@
 #include <cmetrics/cmt_atomic.h>
 #include <cmetrics/cmt_compat.h>
 #include <cmetrics/cmt_label.h>
+#include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_version.h>
 
 #include <cfl/cfl_kvlist.h>
@@ -142,6 +143,42 @@ void cmt_destroy(struct cmt *cmt)
     }
 
     free(cmt);
+}
+
+void cmt_expire(struct cmt *cmt, uint64_t expiration)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct cmt_counter *c;
+    struct cmt_gauge *g;
+    struct cmt_summary *s;
+    struct cmt_histogram *h;
+    struct cmt_untyped *u;
+
+    cfl_list_foreach_safe(head, tmp, &cmt->counters) {
+        c = cfl_list_entry(head, struct cmt_counter, _head);
+        cmt_map_metrics_expire(c->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->gauges) {
+        g = cfl_list_entry(head, struct cmt_gauge, _head);
+        cmt_map_metrics_expire(g->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->summaries) {
+        s = cfl_list_entry(head, struct cmt_summary, _head);
+        cmt_map_metrics_expire(s->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->histograms) {
+        h = cfl_list_entry(head, struct cmt_histogram, _head);
+        cmt_map_metrics_expire(s->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->untypeds) {
+        u = cfl_list_entry(head, struct cmt_untyped, _head);
+        cmt_map_metrics_expire(u->map, expiration);
+    }
 }
 
 int cmt_label_add(struct cmt *cmt, char *key, char *val)

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -145,6 +145,61 @@ void cmt_destroy(struct cmt *cmt)
     free(cmt);
 }
 
+void cmt_expire(struct cmt *cmt, uint64_t expiration)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_summary *summary;
+    struct cmt_histogram *histogram;
+    struct cmt_untyped *untyped;
+    struct cmt_exp_histogram *exp_histogram;
+
+    if (cmt == NULL) {
+        return;
+    }
+
+    /* Do a first pass for all regular metrics: 
+     *  * counters
+     *  * gauges
+     *  * summaries
+     *  * histograms
+     *  * untypeds
+     */
+    cfl_list_foreach_safe(head, tmp, &cmt->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+        cmt_map_metrics_expire(counter->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+        cmt_map_metrics_expire(gauge->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+        cmt_map_metrics_expire(summary->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+        cmt_map_metrics_expire(histogram->map, expiration);
+    }
+
+    cfl_list_foreach_safe(head, tmp, &cmt->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+        cmt_map_metrics_expire(untyped->map, expiration);
+    }
+
+    /* Here we cover exp_histograms separetely.
+     */
+    cfl_list_foreach_safe(head, tmp, &cmt->exp_histograms) {
+        exp_histogram = cfl_list_entry(head, struct cmt_exp_histogram, _head);
+        cmt_map_metrics_expire(exp_histogram->map, expiration);
+    }
+}
+
 int cmt_label_add(struct cmt *cmt, char *key, char *val)
 {
     return cmt_labels_add_kv(cmt->static_labels, key, val);

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -333,3 +333,20 @@ void destroy_label_list(struct cfl_list *label_list)
         free(label);
     }
 }
+
+/* This function can be used to expire untouched metrics.
+ */
+int cmt_map_metrics_expire(struct cmt_map *map, uint64_t expiration)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct cmt_metric *metric;
+
+    cfl_list_foreach_safe(head, tmp, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        if (metric->timestamp <= expiration) {
+            cmt_map_metric_destroy(metric);
+        }
+    }
+    return 0;
+}

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -338,3 +338,19 @@ void destroy_label_list(struct cfl_list *label_list)
         free(label);
     }
 }
+
+/* This function can be used to expire untouched metrics.
+ */
+void cmt_map_metrics_expire(struct cmt_map *map, uint64_t expiration)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct cmt_metric *metric;
+
+    cfl_list_foreach_safe(head, tmp, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        if (metric->timestamp < expiration) {
+            cmt_map_metric_destroy(metric);
+        }
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UNIT_TESTS_FILES
   filter.c
   exp_histogram.c
   msgpack_abi.c
+  expire.c
   )
 
 if (CMT_BUILD_PROMETHEUS_TEXT_DECODER)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UNIT_TESTS_FILES
   filter.c
   exp_histogram.c
   msgpack_abi.c
+  expire.c
   )
 
 if (CMT_BUILD_PROMETHEUS_TEXT_DECODER)
@@ -42,11 +43,16 @@ foreach(source_file ${UNIT_TESTS_FILES})
     encode_output.c
     )
 
-  target_link_libraries(${source_file_we} cmetrics-static cfl-static fluent-otel-proto)
+  target_link_libraries(${source_file_we} cmetrics-static fluent-otel-proto)
+  if (CMT_HAVE_CFL)
+    target_link_libraries(${source_file_we} cfl)
+  else()
+    target_link_libraries(${source_file_we} cfl-static)
+  endif()
 
-if(NOT CMT_SYSTEM_WINDOWS)
-  target_link_libraries(${source_file_we} pthread)
-endif()
+  if(NOT CMT_SYSTEM_WINDOWS)
+    target_link_libraries(${source_file_we} pthread)
+  endif()
 
   add_test(NAME ${source_file_we}
     COMMAND ${CMAKE_BINARY_DIR}/tests/${source_file_we}

--- a/tests/expire.c
+++ b/tests/expire.c
@@ -1,0 +1,185 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021-2022 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_encode_prometheus.h>
+
+#include "cmt_tests.h"
+
+void test_expire_counter()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_counter *c;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a counter metric type */
+    c = cmt_counter_create(cmt, "k8s", "network", "uptime", "Network Uptime", 1, (char *[]) {"host"});
+    TEST_CHECK(c != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_counter_inc(c, ts, 1, (char *[]){"valid"});
+    cmt_counter_inc(c, ts-10, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_gauge()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_gauge *g;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a gauge metric type */
+    g = cmt_gauge_create(cmt, "k8s", "network", "load", "Network load", 1, (char *[]) {"host"});
+    TEST_CHECK(g != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_gauge_set(g, ts, 50, 1, (char *[]){"valid"});
+    cmt_gauge_set(g, ts-10, 50, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_histogram()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(11,
+                                           0.005, 0.01, 0.025, 0.05,
+                                           0.1, 0.25, 0.5, 1.0, 2.5,
+                                           5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a histogram metric type */
+    h = cmt_histogram_create(cmt,
+                             "k8s", "network", "uptime", "Network Uptime",
+                             buckets,
+                             1, (char *[]) {"host"});
+    TEST_CHECK(h != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_histogram_observe(h, ts, 1.0, 1, (char *[]){"valid"});
+    cmt_histogram_observe(h, ts-10, 1.0, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&h->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&h->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_summary()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_summary *s;
+    double quantiles[6];
+    double revised[6];
+    double sum;
+    uint64_t count;
+
+    /* set quantiles, no labels */
+    quantiles[0] = 0.1;
+    quantiles[1] = 0.2;
+    quantiles[2] = 0.3;
+    quantiles[3] = 0.4;
+    quantiles[4] = 0.5;
+    quantiles[5] = 1.0;
+
+    revised[0] = 1.0;
+    revised[1] = 2.0;
+    revised[2] = 3.0;
+    revised[3] = 4.0;
+    revised[4] = 5.0;
+    revised[5] = 6.0;
+
+    count = 10;
+    sum   = 51.612894511314444;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a summary metric type */
+    s = cmt_summary_create(cmt,
+                             "k8s", "network", "uptime", "Network Uptime",
+                             6,
+                             quantiles,
+                             1, (char *[]) {"host"});
+    TEST_CHECK(s != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_summary_set_default(s, ts, revised, sum, count, 1, (char *[]){"valid"});
+    cmt_summary_set_default(s, ts-10, revised, sum, count, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&s->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&s->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+TEST_LIST = {
+    {"expire_counter" , test_expire_counter},
+    {"expire_gauge" , test_expire_gauge},
+    {"expire_histogram" , test_expire_histogram},
+    {"expire_summary", test_expire_summary},
+    { 0 }
+};

--- a/tests/expire.c
+++ b/tests/expire.c
@@ -1,0 +1,321 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021-2022 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_exp_histogram.h>
+#include <cmetrics/cmt_untyped.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_encode_prometheus.h>
+
+#include "cmt_tests.h"
+
+void test_expire_counter()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_counter *c;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a counter metric type */
+    c = cmt_counter_create(cmt, "k8s", "network", "uptime", "Network Uptime", 1, (char *[]) {"host"});
+    TEST_CHECK(c != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_counter_inc(c, ts, 1, (char *[]){"valid"});
+    cmt_counter_inc(c, ts-10, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_gauge()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_gauge *g;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a gauge metric type */
+    g = cmt_gauge_create(cmt, "k8s", "network", "load", "Network load", 1, (char *[]) {"host"});
+    TEST_CHECK(g != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_gauge_set(g, ts, 50, 1, (char *[]){"valid"});
+    cmt_gauge_set(g, ts-10, 50, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&g->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_histogram()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(11,
+                                           0.005, 0.01, 0.025, 0.05,
+                                           0.1, 0.25, 0.5, 1.0, 2.5,
+                                           5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a histogram metric type */
+    h = cmt_histogram_create(cmt,
+                             "k8s", "network", "uptime", "Network Uptime",
+                             buckets,
+                             1, (char *[]) {"host"});
+    TEST_CHECK(h != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_histogram_observe(h, ts, 1.0, 1, (char *[]){"valid"});
+    cmt_histogram_observe(h, ts-10, 1.0, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&h->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&h->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_summary()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_summary *s;
+    double quantiles[6];
+    double revised[6];
+    double sum;
+    uint64_t count;
+
+    /* set quantiles, no labels */
+    quantiles[0] = 0.1;
+    quantiles[1] = 0.2;
+    quantiles[2] = 0.3;
+    quantiles[3] = 0.4;
+    quantiles[4] = 0.5;
+    quantiles[5] = 1.0;
+
+    revised[0] = 1.0;
+    revised[1] = 2.0;
+    revised[2] = 3.0;
+    revised[3] = 4.0;
+    revised[4] = 5.0;
+    revised[5] = 6.0;
+
+    count = 10;
+    sum   = 51.612894511314444;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a summary metric type */
+    s = cmt_summary_create(cmt,
+                             "k8s", "network", "uptime", "Network Uptime",
+                             6,
+                             quantiles,
+                             1, (char *[]) {"host"});
+    TEST_CHECK(s != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_summary_set_default(s, ts, revised, sum, count, 1, (char *[]){"valid"});
+    cmt_summary_set_default(s, ts-10, revised, sum, count, 1, (char *[]){"expire"});
+
+    TEST_CHECK(cfl_list_size(&s->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&s->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_untyped()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_untyped *u;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    u = cmt_untyped_create(cmt, "cmetrics", "test", "cat_untyped", "first untyped",
+                           2, (char *[]) {"label5", "label6"});
+    TEST_CHECK(u != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_untyped_set(u, ts, 1.3, 2, (char *[]) {"first", "valid"});
+    cmt_untyped_set(u, ts-10, 1.3, 2, (char *[]) {"second", "expire"});
+
+    TEST_CHECK(cfl_list_size(&u->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&u->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_epxire_exp_histogram()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    uint64_t positive[3] = {3, 5, 7};
+    uint64_t negative[2] = {2, 1};
+    int result;
+    struct cmt_exp_histogram *exp_histogram;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    exp_histogram = cmt_exp_histogram_create(cmt,
+                                             "cm", "native", "exp_hist", "native exp histogram",
+                                             1, (char *[]) {"endpoint"});
+    TEST_CHECK(exp_histogram != NULL);
+
+    if (exp_histogram == NULL) {
+        return;
+    }
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    result = cmt_exp_histogram_set_default(exp_histogram,
+                                           ts,
+                                           2,
+                                           11,
+                                           0.0,
+                                           -2,
+                                           3,
+                                           positive,
+                                           -1,
+                                           2,
+                                           negative,
+                                           CMT_TRUE,
+                                           42.25,
+                                           29,
+                                           1,
+                                           (char *[]) {"api"});
+    TEST_CHECK(result == 0);
+    result = cmt_exp_histogram_set_default(exp_histogram,
+                                           ts-10,
+                                           2,
+                                           11,
+                                           0.0,
+                                           -2,
+                                           3,
+                                           positive,
+                                           -1,
+                                           2,
+                                           negative,
+                                           CMT_TRUE,
+                                           42.25,
+                                           29,
+                                           1,
+                                           (char *[]) {"http"});
+    TEST_CHECK(result == 0);
+
+    TEST_CHECK(cfl_list_size(&exp_histogram->map->metrics) == 2);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&exp_histogram->map->metrics) == 1);
+
+    cmt_destroy(cmt);
+}
+
+void test_expire_off_by_one()
+{
+    uint64_t ts;
+    struct cmt *cmt;
+    struct cmt_counter *c;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a counter metric type */
+    c = cmt_counter_create(cmt, "k8s", "network", "uptime", "Network Uptime", 1, (char *[]) {"host"});
+    TEST_CHECK(c != NULL);
+
+    /* Timestamp */
+    ts = cfl_time_now();
+
+    cmt_counter_inc(c, ts, 1, (char *[]){"fullyvalid"});
+    cmt_counter_inc(c, ts-1, 1, (char *[]){"bordervalid"});
+    cmt_counter_inc(c, ts-2, 1, (char *[]){"borderexpire"});
+
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 3);
+    cmt_expire(cmt, ts-2);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 3);
+    cmt_expire(cmt, ts-1);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 2);
+    cmt_expire(cmt, ts);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 1);
+    cmt_expire(cmt, ts+1);
+    TEST_CHECK(cfl_list_size(&c->map->metrics) == 0);
+
+    cmt_destroy(cmt);
+}
+
+TEST_LIST = {
+    {"expire_counter"    ,   test_expire_counter},
+    {"expire_gauge",         test_expire_gauge},
+    {"expire_histogram",     test_expire_histogram},
+    {"expire_summary",       test_expire_summary},
+    {"expire_untyped",       test_expire_untyped},
+    {"expire_exp_histogram", test_epxire_exp_histogram},
+    {"expire_off_by_one",    test_expire_off_by_one},
+    { 0 }
+};


### PR DESCRIPTION
Add two new functions, `cmt_map_metrics_expire` for expiring metrics in a `cmt_map` and `cmt_expire` which uses the function to expire all the metrics inside a `cmetrics` context.

This function is useful in general for removing metrics with labels for objects that will disappear, ie: PIDs, etc...

This will also be used in fluent/fluent-bit#7615.