### PR TITLE
cmetrics: improved Windows support

### DIFF
--- a/include/cmetrics/cmt_compat.h
+++ b/include/cmetrics/cmt_compat.h
@@ -22,7 +22,13 @@
 
 #include <time.h>
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#else
+#include <windows.h>
+#endif
 #endif
 
 static inline struct tm *cmt_platform_gmtime_r(const time_t *timep, struct tm *result)

--- a/src/cmt_atomic_msvc.c
+++ b/src/cmt_atomic_msvc.c
@@ -18,7 +18,13 @@
  */
 
 #include <cmetrics/cmt_atomic.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#else
+#include <windows.h>
+#endif
 
 /* This allows cmt_atomic_initialize to be automatically called 
  * as soon as the program starts if enabled.


### PR DESCRIPTION
metric: reduced windows.h include to avoid redeclaration conflicts (https://github.com/fluent/fluent-bit/pull/11472#discussion_r2962300645).

Refer to explanation of this solution in https://github.com/boostorg/stacktrace/pull/157.