### PR TITLE
encode: prevent appending .0 to scientific notation to le bucket labels

### DIFF
--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdbool.h>
+#include <math.h>
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_metric.h>
@@ -373,7 +374,11 @@ static cfl_sds_t bucket_value_to_string(double val)
     len = snprintf(str, 64, "%g", val);
     cfl_sds_len_set(str, len);
 
-    if (!strchr(str, '.')) {
+    /*
+     * Append .0 only when there is no decimal point and the number
+     * is finite and not in scientific notation.
+     */
+    if (isfinite(val) && !strchr(str, '.') && !strchr(str, 'e')) {
         cfl_sds_cat_safe(&str, ".0", 2);
     }
 

--- a/tests/histogram.c
+++ b/tests/histogram.c
@@ -109,6 +109,55 @@ static void prometheus_encode_test(struct cmt *cmt)
     cmt_encode_prometheus_destroy(buf);
 }
 
+void test_histogram_special_bucket_labels()
+{
+    /* Cover scientific notation and non-finite %g outputs like inf/nan. */
+    uint64_t ts;
+    cfl_sds_t buf;
+    struct cmt *cmt;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt_initialize();
+
+    ts = 0;
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    buckets = cmt_histogram_buckets_create(4, -INFINITY, 100000000.0, NAN, INFINITY);
+    TEST_CHECK(buckets != NULL);
+
+    h = cmt_histogram_create(cmt,
+                             "cm", "encoding", "scientific_bucket",
+                             "Histogram scientific bucket label",
+                             buckets,
+                             0, NULL);
+    TEST_CHECK(h != NULL);
+
+    cmt_histogram_observe(h, ts, 42.0, 0, NULL);
+
+    buf = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    TEST_CHECK(buf != NULL);
+    if (buf != NULL) {
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_scientific_bucket_bucket{le=\"-inf\"} 0 0") != NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_scientific_bucket_bucket{le=\"1e+08\"} 1 0") != NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_scientific_bucket_bucket{le=\"1e+08.0\"}") == NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_scientific_bucket_bucket{le=\"nan\"} 1 0") != NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_scientific_bucket_bucket{le=\"inf\"} 1 0") != NULL);
+        TEST_CHECK(strstr(buf, "le=\"-inf.0\"") == NULL);
+        TEST_CHECK(strstr(buf, "le=\"nan.0\"") == NULL);
+        TEST_CHECK(strstr(buf, "le=\"inf.0\"") == NULL);
+        cmt_encode_prometheus_destroy(buf);
+    }
+
+    cmt_destroy(cmt);
+}
+
 
 void test_histogram()
 {
@@ -206,6 +255,7 @@ void test_set_defaults()
 }
 
 TEST_LIST = {
+    {"special_bucket_labels", test_histogram_special_bucket_labels},
     {"histogram"   , test_histogram},
     {"set_defaults", test_set_defaults},
     { 0 }


### PR DESCRIPTION
`bucket_value_to_string` used %g to format histogram bucket boundaries, which switches to scientific notation for values >= 1e6. The subsequent check for a missing decimal point would then append ".0", producing malformed `le` labels like "1e+06.0" that Prometheus rejects with:

```
bucket label "le" is missing or has a malformed value of "1e+08.0"
```

Skip the ".0" suffix when the string already contains 'e', since scientific notation is valid in Prometheus `le` labels without it.

This PR also handles non finite values as `nan`, `-inf` and `inf`.