### PR TITLE
prometheus_remote_write: preserve sparse metadata histograms

### DIFF
--- a/include/cmetrics/cmt_encode_prometheus_remote_write.h
+++ b/include/cmetrics/cmt_encode_prometheus_remote_write.h
@@ -42,7 +42,6 @@ struct cmt_prometheus_metric_metadata {
 struct cmt_prometheus_time_series {
     uint64_t               label_set_hash;
     size_t                 entries_set;
-    size_t                 samples_capacity;
     Prometheus__TimeSeries data;
     struct cfl_list _head;
 };

--- a/src/cmt_decode_opentelemetry.c
+++ b/src/cmt_decode_opentelemetry.c
@@ -270,7 +270,7 @@ static struct cmt_map_label *create_label(char *caption, size_t length)
     instance = calloc(1, sizeof(struct cmt_map_label));
 
     if (instance != NULL) {
-        if (length == 0) {
+        if (length == (size_t) -1) {
             length = strlen(caption);
         }
 
@@ -538,7 +538,7 @@ static int append_new_map_label_key(struct cmt_map *map, char *name)
 {
     struct cmt_map_label *label;
 
-    label = create_label(name, 0);
+    label = create_label(name, (size_t) -1);
 
     if (label == NULL) {
         return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
@@ -655,7 +655,7 @@ static int decode_data_point_labels(struct cmt *cmt,
                 result = append_new_metric_label_value(metric,
                                                        attribute->value->string_value != NULL ?
                                                        attribute->value->string_value : "",
-                                                       0);
+                                                       (size_t) -1);
             }
             else if (attribute->value->value_case ==
                      OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE_STRINDEX) {
@@ -676,17 +676,17 @@ static int decode_data_point_labels(struct cmt *cmt,
             else if (attribute->value->value_case == OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_BOOL_VALUE) {
                 snprintf(dummy_label_value, sizeof(dummy_label_value) - 1, "%d", attribute->value->bool_value);
 
-                result = append_new_metric_label_value(metric, dummy_label_value, 0);
+                result = append_new_metric_label_value(metric, dummy_label_value, (size_t) -1);
             }
             else if (attribute->value->value_case == OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_INT_VALUE) {
                 snprintf(dummy_label_value, sizeof(dummy_label_value) - 1, "%" PRIi64, attribute->value->int_value);
 
-                result = append_new_metric_label_value(metric, dummy_label_value, 0);
+                result = append_new_metric_label_value(metric, dummy_label_value, (size_t) -1);
             }
             else if (attribute->value->value_case == OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_DOUBLE_VALUE) {
                 snprintf(dummy_label_value, sizeof(dummy_label_value) - 1, "%.17g", attribute->value->double_value);
 
-                result = append_new_metric_label_value(metric, dummy_label_value, 0);
+                result = append_new_metric_label_value(metric, dummy_label_value, (size_t) -1);
             }
             else {
                 result = append_new_metric_label_value(metric, "", 0);

--- a/src/cmt_decode_prometheus_remote_write.c
+++ b/src/cmt_decode_prometheus_remote_write.c
@@ -375,6 +375,10 @@ static int decode_histogram_points(struct cmt *cmt,
                                    Prometheus__Label **labels)
 {
     int                   i;
+    int                   bucket_index;
+    size_t                count_index;
+    size_t                count_size;
+    size_t                span_index;
     int                   static_metric_detected;
     struct cmt_histogram *histogram;
     struct cmt_metric    *metric;
@@ -389,23 +393,53 @@ static int decode_histogram_points(struct cmt *cmt,
 
     if (histogram->buckets == NULL) {
         if (hist->n_negative_spans > 0) {
-            spans = calloc(1, sizeof(double) * hist->n_negative_spans);
-
-            for (i = 0; i < hist->n_negative_spans; i++) {
-                spans[i] = (double) hist->negative_spans[i]->offset;
+            count_size = hist->n_negative_counts;
+            spans = calloc(1, sizeof(double) * count_size);
+            if (spans == NULL) {
+                return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
             }
+
+            bucket_index = 0;
+            count_index = 0;
+            for (span_index = 0; span_index < hist->n_negative_spans; span_index++) {
+                bucket_index += hist->negative_spans[span_index]->offset;
+
+                for (i = 0; i < hist->negative_spans[span_index]->length; i++) {
+                    if (count_index >= count_size) {
+                        break;
+                    }
+
+                    spans[count_index++] = (double) bucket_index++;
+                }
+            }
+
             histogram->buckets = cmt_histogram_buckets_create_size(spans,
-                                                                   hist->n_negative_spans);
+                                                                   count_index);
             free(spans);
         }
         else if (hist->n_positive_spans > 0) {
-            spans = calloc(1, sizeof(double) * hist->n_positive_spans);
-
-            for (i = 0; i < hist->n_positive_spans; i++) {
-                spans[i] = (double) hist->positive_spans[i]->offset;
+            count_size = hist->n_positive_counts;
+            spans = calloc(1, sizeof(double) * count_size);
+            if (spans == NULL) {
+                return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
             }
+
+            bucket_index = 0;
+            count_index = 0;
+            for (span_index = 0; span_index < hist->n_positive_spans; span_index++) {
+                bucket_index += hist->positive_spans[span_index]->offset;
+
+                for (i = 0; i < hist->positive_spans[span_index]->length; i++) {
+                    if (count_index >= count_size) {
+                        break;
+                    }
+
+                    spans[count_index++] = (double) bucket_index++;
+                }
+            }
+
             histogram->buckets = cmt_histogram_buckets_create_size(spans,
-                                                                   hist->n_positive_spans);
+                                                                   count_index);
             free(spans);
         }
 
@@ -452,6 +486,26 @@ static int decode_histogram_points(struct cmt *cmt,
         map->metric_static_set = CMT_TRUE;
     }
 
+    if (metric->hist_buckets == NULL) {
+        metric->hist_buckets = calloc(1, sizeof(uint64_t) *
+                                      (histogram->buckets->count + 1));
+        if (metric->hist_buckets == NULL) {
+            if (static_metric_detected == CMT_FALSE) {
+                if (metric->hist_buckets != NULL) {
+                    free(metric->hist_buckets);
+                }
+
+                destroy_label_list(&metric->labels);
+
+                cfl_list_del(&metric->_head);
+
+                free(metric);
+            }
+
+            return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
+        }
+    }
+
     if (result == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
         if (hist->n_negative_spans > 0) {
             for (i = 0; i < hist->n_negative_counts; i++) {
@@ -467,6 +521,10 @@ static int decode_histogram_points(struct cmt *cmt,
         }
         else {
             if (static_metric_detected == CMT_FALSE) {
+                if (metric->hist_buckets != NULL) {
+                    free(metric->hist_buckets);
+                }
+
                 destroy_label_list(&metric->labels);
 
                 cfl_list_del(&metric->_head);
@@ -489,6 +547,10 @@ static int decode_histogram_points(struct cmt *cmt,
     }
     else {
         if (static_metric_detected == CMT_FALSE) {
+            if (metric->hist_buckets != NULL) {
+                free(metric->hist_buckets);
+            }
+
             destroy_label_list(&metric->labels);
 
             cfl_list_del(&metric->_head);
@@ -578,12 +640,12 @@ static int decode_metrics_entry(struct cmt *cmt,
         if (meta_count > i) {
             metadata = write->metadata[i];
         }
-        if (metadata == NULL) {
-            type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__GAUGE;
+        if (hist_count > 0) {
+            type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__HISTOGRAM;
             metric_description = "-";
         }
-        else if (hist_count > 0) {
-            type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__HISTOGRAM;
+        else if (metadata == NULL) {
+            type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__GAUGE;
             metric_description = "-";
         }
         else {
@@ -666,13 +728,16 @@ static int decode_metrics_entry(struct cmt *cmt,
                                             metric_subsystem,
                                             metric_name,
                                             metric_description,
-                                            (struct cmt_histogram_buckets *) cmt,
+                                            NULL,
                                             0, NULL);
 
             if (instance == NULL) {
                 free(metric_name);
                 return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
             }
+
+            cmt_histogram_buckets_destroy(((struct cmt_histogram *) instance)->buckets);
+            ((struct cmt_histogram *) instance)->buckets = NULL;
 
             result = decode_histogram_entry(cmt, instance, ts);
 

--- a/src/cmt_encode_influx.c
+++ b/src/cmt_encode_influx.c
@@ -266,8 +266,8 @@ static int append_string(cfl_sds_t *buf, cfl_sds_t str)
 static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
                           struct cmt_metric *metric)
 {
-    int i;
     int n;
+    int emitted_count = 0;
     int static_count = 0;
     int static_labels = 0;
     int has_namespace = CMT_FALSE;
@@ -327,13 +327,8 @@ static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
     n = cfl_list_size(&metric->labels);
     label_key_count = map->label_count;
     if (n > 0 && label_key_count > 0) {
-        if (static_labels > 0 || has_namespace == CMT_TRUE) {
-            cfl_sds_cat_safe(buf, ",", 1);
-        }
-
         label_k = cfl_list_entry_first(&map->label_keys, struct cmt_map_label, _head);
 
-        i = 1;
         label_index = 0;
         cfl_list_foreach(head, &metric->labels) {
             if (label_index >= label_key_count) {
@@ -349,15 +344,16 @@ static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
                 continue;
             }
 
+            if (static_labels > 0 || has_namespace == CMT_TRUE ||
+                emitted_count > 0) {
+                cfl_sds_cat_safe(buf, ",", 1);
+            }
+
             /* key */
             append_string(buf, label_k->name);
             cfl_sds_cat_safe(buf, "=", 1);
             append_string(buf, label_v->name);
-
-            if (i < n) {
-                cfl_sds_cat_safe(buf, ",", 1);
-            }
-            i++;
+            emitted_count++;
 
             label_index++;
             label_k = cfl_list_entry_next(&label_k->_head, struct cmt_map_label,
@@ -365,7 +361,7 @@ static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
         }
     }
 
-    if (has_namespace == CMT_TRUE || static_labels > 0 || n > 0) {
+    if (has_namespace == CMT_TRUE || static_labels > 0 || emitted_count > 0) {
         cfl_sds_cat_safe(buf, " ", 1);
     }
     append_metric_value(map, buf, metric);

--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -400,7 +400,7 @@ static cfl_sds_t bucket_value_to_string(double val)
     len = snprintf(str, 64, "%g", val);
     parsed = strtod(str, NULL);
     if (parsed != val) {
-        len = snprintf(str, 64, "%.15g", val);
+        len = snprintf(str, 64, "%.17g", val);
     }
     cfl_sds_len_set(str, len);
 

--- a/src/cmt_encode_prometheus_remote_write.c
+++ b/src/cmt_encode_prometheus_remote_write.c
@@ -34,6 +34,14 @@
 #define SYNTHETIC_METRIC_HISTOGRAM_COUNT_SEQUENCE_DELTA 10000000
 #define SYNTHETIC_METRIC_HISTOGRAM_SUM_SEQUENCE_DELTA   100000000
 
+struct cmt_prometheus_time_series_entry {
+    uint64_t               label_set_hash;
+    size_t                 entries_set;
+    Prometheus__TimeSeries data;
+    struct cfl_list        _head;
+    size_t                 samples_capacity;
+};
+
 static cfl_sds_t render_remote_write_context_to_sds(
     struct cmt_prometheus_remote_write_context *context);
 
@@ -61,13 +69,13 @@ static int set_up_time_series_for_label_set(
                                     struct cmt_prometheus_remote_write_context *context,
                                     struct cmt_map *map,
                                     struct cmt_metric *metric,
-                                    struct cmt_prometheus_time_series **time_series);
+                                    struct cmt_prometheus_time_series_entry **time_series);
 
 static int pack_metric_metadata(struct cmt_prometheus_remote_write_context *context,
                                 struct cmt_map *map,
                                 struct cmt_metric *metric);
 
-static int append_metric_to_timeseries(struct cmt_prometheus_time_series *time_series,
+static int append_metric_to_timeseries(struct cmt_prometheus_time_series_entry *time_series,
                                        struct cmt_metric *metric);
 
 static int pack_basic_type(struct cmt_prometheus_remote_write_context *context,
@@ -111,7 +119,7 @@ cfl_sds_t render_remote_write_context_to_sds(
     struct cmt_prometheus_remote_write_context *context)
 {
     size_t                                 write_request_size;
-    struct cmt_prometheus_time_series     *time_series_entry;
+    struct cmt_prometheus_time_series_entry     *time_series_entry;
     struct cmt_prometheus_metric_metadata *metadata_entry;
     cfl_sds_t                              result_buffer;
     size_t                                 entry_index;
@@ -143,7 +151,7 @@ cfl_sds_t render_remote_write_context_to_sds(
     entry_index = 0;
 
     cfl_list_foreach(head, &context->time_series_entries) {
-        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series, _head);
+        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series_entry, _head);
 
         context->write_request.timeseries[entry_index++] = &time_series_entry->data;
     }
@@ -176,13 +184,13 @@ cfl_sds_t render_remote_write_context_to_sds(
 void cmt_destroy_prometheus_remote_write_context(
     struct cmt_prometheus_remote_write_context *context)
 {
-    struct cmt_prometheus_time_series     *time_series_entry;
+    struct cmt_prometheus_time_series_entry     *time_series_entry;
     struct cmt_prometheus_metric_metadata *metadata_entry;
     struct cfl_list                        *head;
     struct cfl_list                        *tmp;
 
     cfl_list_foreach_safe(head, tmp, &context->time_series_entries) {
-        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series, _head);
+        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series_entry, _head);
 
         if (time_series_entry->data.labels != NULL) {
             destroy_prometheus_label_list(time_series_entry->data.labels,
@@ -355,11 +363,11 @@ void destroy_prometheus_label_list(Prometheus__Label **label_list,
 int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context *context,
                                      struct cmt_map *map,
                                      struct cmt_metric *metric,
-                                     struct cmt_prometheus_time_series **time_series)
+                                     struct cmt_prometheus_time_series_entry **time_series)
 {
     uint8_t                            time_series_match_found;
     size_t                             label_set_hash_matches;
-    struct cmt_prometheus_time_series *time_series_entry;
+    struct cmt_prometheus_time_series_entry *time_series_entry;
     uint64_t                           label_set_hash;
     struct cmt_label                  *static_label;
     size_t                             label_index;
@@ -380,7 +388,7 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
     time_series_match_found = CMT_FALSE;
 
     cfl_list_foreach(head, &context->time_series_entries) {
-        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series, _head);
+        time_series_entry = cfl_list_entry(head, struct cmt_prometheus_time_series_entry, _head);
 
         if (time_series_entry->label_set_hash == label_set_hash) {
             time_series_match_found = CMT_TRUE;
@@ -414,7 +422,7 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
                   1;
 
 
-    time_series_entry = calloc(1, sizeof(struct cmt_prometheus_time_series));
+    time_series_entry = calloc(1, sizeof(struct cmt_prometheus_time_series_entry));
 
     if (time_series_entry == NULL) {
         cmt_errno();
@@ -453,6 +461,7 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
 
     time_series_entry->label_set_hash = label_set_hash;
     time_series_entry->entries_set = 0;
+    /* Capacity is initialized to at least one and grows geometrically. */
     time_series_entry->samples_capacity = label_set_hash_matches;
 
     /* Initialize the label list */
@@ -624,7 +633,7 @@ int pack_metric_metadata(struct cmt_prometheus_remote_write_context *context,
     return 0;
 }
 
-int append_metric_to_timeseries(struct cmt_prometheus_time_series *time_series,
+int append_metric_to_timeseries(struct cmt_prometheus_time_series_entry *time_series,
                                 struct cmt_metric *metric)
 {
     uint64_t ts;
@@ -634,9 +643,6 @@ int append_metric_to_timeseries(struct cmt_prometheus_time_series *time_series,
 
     if (time_series->entries_set >= time_series->samples_capacity) {
         new_capacity = time_series->samples_capacity * 2;
-        if (new_capacity == 0) {
-            new_capacity = 1;
-        }
 
         samples = realloc(time_series->data.samples,
                           new_capacity * sizeof(Prometheus__Sample *));
@@ -679,7 +685,7 @@ int pack_basic_metric_sample(struct cmt_prometheus_remote_write_context *context
                              struct cmt_metric *metric,
                              int add_metadata)
 {
-    struct cmt_prometheus_time_series *time_series;
+    struct cmt_prometheus_time_series_entry *time_series;
     int                                result;
 
     result = set_up_time_series_for_label_set(context, map, metric, &time_series);
@@ -774,7 +780,7 @@ int pack_complex_metric_sample(struct cmt_prometheus_remote_write_context *conte
     size_t                             label_key_count;
     struct cmt_map_label              *additional_label;
     struct cmt_metric                  dummy_metric;
-    struct cmt_prometheus_time_series *time_series;
+    struct cmt_prometheus_time_series_entry *time_series;
     struct cmt_map_label              *dummy_label;
     struct cmt_histogram              *histogram = NULL;
     struct cmt_summary                *summary;

--- a/src/cmt_encode_splunk_hec.c
+++ b/src/cmt_encode_splunk_hec.c
@@ -266,9 +266,9 @@ cleanup:
 static void format_metric_labels(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
                                  struct cmt_metric *metric)
 {
-    int i;
     int n;
     int count = 0;
+    int emitted_any = CMT_TRUE;
     int static_labels = 0;
     int label_key_count;
     int label_index;
@@ -300,10 +300,8 @@ static void format_metric_labels(struct cmt_splunk_hec_context *context, cfl_sds
     n = cfl_list_size(&metric->labels);
     label_key_count = map->label_count;
     if (n > 0 && label_key_count > 0) {
-        cfl_sds_cat_safe(buf, ",", 1);
         label_k = cfl_list_entry_first(&map->label_keys, struct cmt_map_label, _head);
 
-        i = 0;
         label_index = 0;
         cfl_list_foreach(head, &metric->labels) {
             if (label_index >= label_key_count) {
@@ -319,19 +317,19 @@ static void format_metric_labels(struct cmt_splunk_hec_context *context, cfl_sds
                 continue;
             }
 
+            if (emitted_any == CMT_TRUE) {
+                cfl_sds_cat_safe(buf, ",", 1);
+            }
             cfl_sds_cat_safe(buf, "\"", 1);
             cfl_sds_cat_safe(buf, label_k->name, cfl_sds_len(label_k->name));
             cfl_sds_cat_safe(buf, "\":\"", 3);
             cfl_sds_cat_safe(buf, label_v->name, cfl_sds_len(label_v->name));
             cfl_sds_cat_safe(buf, "\"", 1);
-            i++;
+            emitted_any = CMT_TRUE;
 
             label_index++;
             label_k = cfl_list_entry_next(&label_k->_head, struct cmt_map_label,
                                           _head, &map->label_keys);
-            if (i < n) {
-                cfl_sds_cat_safe(buf, ",", 1);
-            }
         }
     }
 }

--- a/tests/decoding.c
+++ b/tests/decoding.c
@@ -18,6 +18,9 @@
  */
 
 #include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_encode_prometheus_remote_write.h>
 #include <cmetrics/cmt_decode_prometheus_remote_write.h>
@@ -64,6 +67,98 @@ static cfl_sds_t generate_remote_write_payload(char *extra_label_name,
 
     time_series_list[0] = &time_series;
     request.n_timeseries = 1;
+    request.timeseries = time_series_list;
+
+    payload_size = prometheus__write_request__get_packed_size(&request);
+    packed_payload = calloc(1, payload_size);
+    if (packed_payload == NULL) {
+        return NULL;
+    }
+
+    prometheus__write_request__pack(&request, packed_payload);
+    payload = cfl_sds_create_len((char *) packed_payload, payload_size);
+    free(packed_payload);
+
+    return payload;
+}
+
+static cfl_sds_t generate_remote_write_sparse_metadata_histogram_payload()
+{
+    Prometheus__WriteRequest request;
+    Prometheus__MetricMetadata metadata;
+    Prometheus__TimeSeries gauge_series;
+    Prometheus__TimeSeries histogram_series;
+    Prometheus__Label gauge_name_label;
+    Prometheus__Label histogram_name_label;
+    Prometheus__Sample sample;
+    Prometheus__Histogram histogram;
+    Prometheus__BucketSpan span;
+    Prometheus__MetricMetadata *metadata_list[1];
+    Prometheus__TimeSeries *time_series_list[2];
+    Prometheus__Label *gauge_label_list[1];
+    Prometheus__Label *histogram_label_list[1];
+    Prometheus__Sample *sample_list[1];
+    Prometheus__Histogram *histogram_list[1];
+    Prometheus__BucketSpan *span_list[1];
+    double positive_counts[3] = {1.0, 2.0, 3.0};
+    size_t payload_size;
+    unsigned char *packed_payload;
+    cfl_sds_t payload;
+
+    prometheus__write_request__init(&request);
+    prometheus__metric_metadata__init(&metadata);
+    prometheus__time_series__init(&gauge_series);
+    prometheus__time_series__init(&histogram_series);
+    prometheus__label__init(&gauge_name_label);
+    prometheus__label__init(&histogram_name_label);
+    prometheus__sample__init(&sample);
+    prometheus__histogram__init(&histogram);
+    prometheus__bucket_span__init(&span);
+
+    metadata.type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__GAUGE;
+    metadata.metric_family_name = "rw_gauge";
+    metadata.help = "remote write gauge";
+    metadata_list[0] = &metadata;
+    request.n_metadata = 1;
+    request.metadata = metadata_list;
+
+    gauge_name_label.name = "__name__";
+    gauge_name_label.value = "rw_gauge";
+    gauge_label_list[0] = &gauge_name_label;
+    gauge_series.n_labels = 1;
+    gauge_series.labels = gauge_label_list;
+
+    sample.value = 1.0;
+    sample.timestamp = 123;
+    sample_list[0] = &sample;
+    gauge_series.n_samples = 1;
+    gauge_series.samples = sample_list;
+
+    histogram_name_label.name = "__name__";
+    histogram_name_label.value = "rw_native_hist";
+    histogram_label_list[0] = &histogram_name_label;
+    histogram_series.n_labels = 1;
+    histogram_series.labels = histogram_label_list;
+
+    span.offset = 1;
+    span.length = 3;
+    span_list[0] = &span;
+    histogram.n_positive_spans = 1;
+    histogram.positive_spans = span_list;
+    histogram.n_positive_counts = 3;
+    histogram.positive_counts = positive_counts;
+    histogram.sum = 6.0;
+    histogram.timestamp = 456;
+    histogram.count_case = PROMETHEUS__HISTOGRAM__COUNT_COUNT_INT;
+    histogram.count_int = 6;
+
+    histogram_list[0] = &histogram;
+    histogram_series.n_histograms = 1;
+    histogram_series.histograms = histogram_list;
+
+    time_series_list[0] = &gauge_series;
+    time_series_list[1] = &histogram_series;
+    request.n_timeseries = 2;
     request.timeseries = time_series_list;
 
     payload_size = prometheus__write_request__get_packed_size(&request);
@@ -143,6 +238,59 @@ void test_prometheus_remote_write_missing_label_value_no_crash()
     }
 }
 
+void test_prometheus_remote_write_sparse_metadata_histogram()
+{
+    int ret;
+    struct cmt_metric *metric;
+    struct cmt_histogram *histogram;
+    struct cmt *decoded_context = NULL;
+    cfl_sds_t payload;
+
+    cmt_initialize();
+
+    payload = generate_remote_write_sparse_metadata_histogram_payload();
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        ret = cmt_decode_prometheus_remote_write_create(&decoded_context,
+                                                        payload,
+                                                        cfl_sds_len(payload));
+        TEST_CHECK(ret == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS);
+        if (ret == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+            TEST_CHECK(cfl_list_size(&decoded_context->gauges) == 1);
+            TEST_CHECK(cfl_list_size(&decoded_context->histograms) == 1);
+
+            histogram = cfl_list_entry_first(&decoded_context->histograms,
+                                             struct cmt_histogram, _head);
+            TEST_CHECK(histogram != NULL);
+            if (histogram != NULL) {
+                TEST_CHECK(histogram->buckets != NULL);
+                if (histogram->buckets != NULL) {
+                    TEST_CHECK(histogram->buckets->count == 3);
+                    TEST_CHECK(histogram->buckets->upper_bounds[0] == 1.0);
+                    TEST_CHECK(histogram->buckets->upper_bounds[1] == 2.0);
+                    TEST_CHECK(histogram->buckets->upper_bounds[2] == 3.0);
+                }
+
+                TEST_CHECK(cfl_list_size(&histogram->map->metrics) == 1);
+                metric = cfl_list_entry_first(&histogram->map->metrics,
+                                              struct cmt_metric, _head);
+                TEST_CHECK(metric != NULL);
+                if (metric != NULL) {
+                    TEST_CHECK(metric->hist_buckets != NULL);
+                    if (metric->hist_buckets != NULL) {
+                        TEST_CHECK(cmt_metric_hist_get_value(metric, 0) == 1);
+                        TEST_CHECK(cmt_metric_hist_get_value(metric, 1) == 2);
+                        TEST_CHECK(cmt_metric_hist_get_value(metric, 2) == 3);
+                    }
+                    TEST_CHECK(cmt_metric_hist_get_count_value(metric) == 6);
+                }
+            }
+            cmt_decode_prometheus_remote_write_destroy(decoded_context);
+        }
+        cfl_sds_destroy(payload);
+    }
+}
+
 void test_statsd()
 {
     int ret;
@@ -178,6 +326,7 @@ TEST_LIST = {
     {"prometheus_remote_write", test_prometheus_remote_write},
     {"prometheus_remote_write_missing_label_name_rejected", test_prometheus_remote_write_missing_label_name_rejected},
     {"prometheus_remote_write_missing_label_value_no_crash", test_prometheus_remote_write_missing_label_value_no_crash},
+    {"prometheus_remote_write_sparse_metadata_histogram", test_prometheus_remote_write_sparse_metadata_histogram},
     {"statsd", test_statsd},
     { 0 }
 };

--- a/tests/null_label.c
+++ b/tests/null_label.c
@@ -19,7 +19,9 @@
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_encode_influx.h>
 #include <cmetrics/cmt_encode_prometheus.h>
+#include <cmetrics/cmt_encode_splunk_hec.h>
 
 #include "cmt_tests.h"
 
@@ -156,6 +158,24 @@ void test_encoding()
         "test_dummy_labels{A=\"a\",B=\"b\",C=\"c\",D=\"d\",E=\"e\",F=\"f\"} 1 0\n"
         ) == 0);
     cfl_sds_destroy(result);
+
+    result = cmt_encode_influx_create(cmt);
+    TEST_CHECK(result != NULL);
+    if (result != NULL) {
+        TEST_CHECK(strstr(result, ", ") == NULL);
+        TEST_CHECK(strstr(result, ",,") == NULL);
+        TEST_CHECK(strstr(result, "B=b") != NULL);
+        cmt_encode_influx_destroy(result);
+    }
+
+    result = cmt_encode_splunk_hec_create(cmt, "localhost", "main", NULL, NULL);
+    TEST_CHECK(result != NULL);
+    if (result != NULL) {
+        TEST_CHECK(strstr(result, ",,") == NULL);
+        TEST_CHECK(strstr(result, ",}") == NULL);
+        TEST_CHECK(strstr(result, "\"B\":\"b\"") != NULL);
+        cmt_encode_splunk_hec_destroy(result);
+    }
 
     cmt_destroy(cmt);
 }

--- a/tests/opentelemetry.c
+++ b/tests/opentelemetry.c
@@ -25,6 +25,7 @@
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_exp_histogram.h>
 #include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_decode_opentelemetry.h>
@@ -492,6 +493,7 @@ static cfl_sds_t generate_gauge_int_otlp_payload_with_unit()
 static cfl_sds_t generate_gauge_int_otlp_payload_with_attribute(char *attribute_key,
                                                                 int include_value)
 {
+    static uint8_t zero_length_bytes_value[1] = {'x'};
     Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest request;
     Opentelemetry__Proto__Metrics__V1__ResourceMetrics resource_metrics;
     Opentelemetry__Proto__Metrics__V1__ScopeMetrics scope_metrics;
@@ -518,7 +520,14 @@ static cfl_sds_t generate_gauge_int_otlp_payload_with_attribute(char *attribute_
     opentelemetry__proto__common__v1__key_value__init(&attribute);
     opentelemetry__proto__common__v1__any_value__init(&attribute_value);
 
-    if (include_value) {
+    if (include_value == 2) {
+        attribute_value.value_case =
+            OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_BYTES_VALUE;
+        attribute_value.bytes_value.data = zero_length_bytes_value;
+        attribute_value.bytes_value.len = 0;
+        attribute.value = &attribute_value;
+    }
+    else if (include_value) {
         attribute_value.value_case =
             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE;
         attribute_value.string_value = "value";
@@ -1433,6 +1442,54 @@ static void test_opentelemetry_missing_attribute_value_no_crash(void)
     }
 }
 
+static void test_opentelemetry_zero_length_bytes_attribute(void)
+{
+    struct cfl_list result_list;
+    struct cmt     *decoded_context;
+    struct cmt_gauge *gauge;
+    struct cmt_metric *metric;
+    struct cmt_map_label *label_value;
+    cfl_sds_t       payload;
+    size_t          offset;
+    int             ret;
+
+    payload = generate_gauge_int_otlp_payload_with_attribute("empty_bytes", 2);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        offset = 0;
+        ret = cmt_decode_opentelemetry_create(&result_list,
+                                              payload, cfl_sds_len(payload),
+                                              &offset);
+        TEST_CHECK(ret == CMT_DECODE_OPENTELEMETRY_SUCCESS);
+        if (ret == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
+            decoded_context = cfl_list_entry_first(&result_list, struct cmt, _head);
+            TEST_CHECK(cfl_list_size(&decoded_context->gauges) == 1);
+            gauge = cfl_list_entry_first(&decoded_context->gauges,
+                                         struct cmt_gauge, _head);
+            TEST_CHECK(gauge != NULL);
+            if (gauge != NULL) {
+                TEST_CHECK(cfl_list_size(&gauge->map->metrics) == 1);
+                metric = cfl_list_entry_first(&gauge->map->metrics,
+                                              struct cmt_metric, _head);
+                TEST_CHECK(metric != NULL);
+                if (metric != NULL) {
+                    label_value = cfl_list_entry_first(&metric->labels,
+                                                       struct cmt_map_label, _head);
+                    TEST_CHECK(label_value != NULL);
+                    if (label_value != NULL) {
+                        TEST_CHECK(label_value->name != NULL);
+                        if (label_value->name != NULL) {
+                            TEST_CHECK(cfl_sds_len(label_value->name) == 0);
+                        }
+                    }
+                }
+            }
+            cmt_decode_opentelemetry_destroy(&result_list);
+        }
+        cfl_sds_destroy(payload);
+    }
+}
+
 TEST_LIST = {
     {"opentelemetry_api_full_roundtrip_with_msgpack", test_opentelemetry_api_full_roundtrip_with_msgpack},
     {"opentelemetry_encode_multi_resource_scope_containers", test_opentelemetry_encode_multi_resource_scope_containers},
@@ -1443,5 +1500,6 @@ TEST_LIST = {
     {"opentelemetry_histogram_null_label_no_crash",   test_opentelemetry_histogram_null_label_no_crash},
     {"opentelemetry_missing_attribute_key_rejected",   test_opentelemetry_missing_attribute_key_rejected},
     {"opentelemetry_missing_attribute_value_no_crash", test_opentelemetry_missing_attribute_value_no_crash},
+    {"opentelemetry_zero_length_bytes_attribute",      test_opentelemetry_zero_length_bytes_attribute},
     { 0 }
 };


### PR DESCRIPTION
- Native histogram samples now take precedence over missing metadata, so sparse metadata no longer defaults them to gauges.
- Fixed the histogram decode path to allocate histogram bucket storage before setting bucket values.
- Removed the bogus bucket sentinel pointer and reset buckets cleanly before decoding native histogram spans.