### PR TITLE
metrics: preserve omitted label semantics

### DIFF
--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -33,6 +33,7 @@
 #include <cmetrics/cmt_mpack_utils.h>
 #include <cmetrics/cmt_atomic.h>
 
+#include <limits.h>
 
 static int create_counter_instance(struct cmt_map *map)
 {
@@ -330,6 +331,7 @@ static int unpack_label(mpack_reader_t *reader,
                         size_t index,
                         struct cfl_list *target_label_list)
 {
+    mpack_tag_t          tag;
     struct cmt_map_label *new_label;
     int                   result;
 
@@ -344,7 +346,27 @@ static int unpack_label(mpack_reader_t *reader,
         return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
 
-    result = cmt_mpack_consume_string_tag(reader, &new_label->name);
+    tag = mpack_peek_tag(reader);
+    if (mpack_ok != mpack_reader_error(reader)) {
+        free(new_label);
+
+        return CMT_DECODE_MSGPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
+    if (mpack_tag_type(&tag) == mpack_type_nil) {
+        mpack_expect_nil(reader);
+        if (mpack_ok != mpack_reader_error(reader)) {
+            free(new_label);
+
+            return CMT_DECODE_MSGPACK_CORRUPT_INPUT_DATA_ERROR;
+        }
+
+        new_label->name = NULL;
+        result = CMT_DECODE_MSGPACK_SUCCESS;
+    }
+    else {
+        result = cmt_mpack_consume_string_tag(reader, &new_label->name);
+    }
 
     if (result != CMT_DECODE_MSGPACK_SUCCESS) {
         free(new_label);
@@ -520,6 +542,11 @@ static int unpack_metric_value_type(mpack_reader_t *reader, size_t index, void *
     int result;
     struct cmt_msgpack_decode_context *decode_context;
 
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
 
     result = cmt_mpack_consume_uint_tag(reader, &value);
@@ -528,6 +555,9 @@ static int unpack_metric_value_type(mpack_reader_t *reader, size_t index, void *
             value == CMT_METRIC_VALUE_UINT64 ||
             value == CMT_METRIC_VALUE_DOUBLE) {
             cmt_atomic_store(&decode_context->metric->value_type, value);
+        }
+        else {
+            result = CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
         }
     }
 
@@ -539,6 +569,11 @@ static int unpack_metric_value_int64(mpack_reader_t *reader, size_t index, void 
     int64_t value;
     int result;
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_int_tag(reader, &value);
@@ -557,6 +592,11 @@ static int unpack_metric_value_uint64(mpack_reader_t *reader, size_t index, void
     uint64_t value;
     int result;
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_uint_tag(reader, &value);
@@ -863,9 +903,18 @@ static int unpack_exp_histogram_scale(mpack_reader_t *reader, size_t index, void
     int64_t value;
     int result;
 
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_int_tag(reader, &value);
     if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        if (value < INT_MIN || value > INT_MAX) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
         decode_context->metric->exp_hist_scale = (int32_t) value;
     }
     return result;
@@ -874,6 +923,12 @@ static int unpack_exp_histogram_scale(mpack_reader_t *reader, size_t index, void
 static int unpack_exp_histogram_zero_count(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->exp_hist_zero_count);
 }
@@ -881,6 +936,12 @@ static int unpack_exp_histogram_zero_count(mpack_reader_t *reader, size_t index,
 static int unpack_exp_histogram_zero_threshold(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     return cmt_mpack_consume_double_tag(reader, &decode_context->metric->exp_hist_zero_threshold);
 }
@@ -891,9 +952,18 @@ static int unpack_exp_histogram_positive_offset(mpack_reader_t *reader, size_t i
     int64_t value;
     int result;
 
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_int_tag(reader, &value);
     if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        if (value < INT_MIN || value > INT_MAX) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
         decode_context->metric->exp_hist_positive_offset = (int32_t) value;
     }
     return result;
@@ -905,9 +975,18 @@ static int unpack_exp_histogram_negative_offset(mpack_reader_t *reader, size_t i
     int64_t value;
     int result;
 
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_int_tag(reader, &value);
     if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        if (value < INT_MIN || value > INT_MAX) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
         decode_context->metric->exp_hist_negative_offset = (int32_t) value;
     }
     return result;
@@ -916,14 +995,36 @@ static int unpack_exp_histogram_negative_offset(mpack_reader_t *reader, size_t i
 static int unpack_exp_histogram_positive_bucket(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
+    if (decode_context->metric->exp_hist_positive_buckets == NULL ||
+        index >= decode_context->metric->exp_hist_positive_count) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->exp_hist_positive_buckets[index]);
 }
 
 static int unpack_exp_histogram_negative_bucket(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
+    if (decode_context->metric->exp_hist_negative_buckets == NULL ||
+        index >= decode_context->metric->exp_hist_negative_count) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->exp_hist_negative_buckets[index]);
 }
 
@@ -931,6 +1032,11 @@ static int unpack_exp_histogram_positive_buckets(mpack_reader_t *reader, size_t 
 {
     struct cmt_msgpack_decode_context *decode_context;
     size_t count;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     count = cmt_mpack_peek_array_length(reader);
@@ -956,6 +1062,11 @@ static int unpack_exp_histogram_negative_buckets(mpack_reader_t *reader, size_t 
 {
     struct cmt_msgpack_decode_context *decode_context;
     size_t count;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     count = cmt_mpack_peek_array_length(reader);
@@ -983,6 +1094,11 @@ static int unpack_exp_histogram_count(mpack_reader_t *reader, size_t index, void
     uint64_t                           value;
     struct cmt_msgpack_decode_context *decode_context;
 
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_uint_tag(reader, &value);
 
@@ -998,6 +1114,11 @@ static int unpack_exp_histogram_sum_set(mpack_reader_t *reader, size_t index, vo
     struct cmt_msgpack_decode_context *decode_context;
     uint64_t value;
     int result;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_uint_tag(reader, &value);
@@ -1015,6 +1136,11 @@ static int unpack_exp_histogram_sum(mpack_reader_t *reader, size_t index, void *
     int                                result;
     uint64_t                           value;
     struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
     result = cmt_mpack_consume_uint_tag(reader, &value);
@@ -1313,6 +1439,19 @@ static int unpack_meta_type(mpack_reader_t *reader, size_t index, void *context)
     result = cmt_mpack_consume_uint_tag(reader, &value);
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
+        if (decode_context->map->parent != NULL) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
+        if (value != CMT_COUNTER &&
+            value != CMT_GAUGE &&
+            value != CMT_SUMMARY &&
+            value != CMT_HISTOGRAM &&
+            value != CMT_EXP_HISTOGRAM &&
+            value != CMT_UNTYPED) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
         decode_context->map->type = value;
 
         result = create_metric_instance(decode_context->map);
@@ -1337,6 +1476,12 @@ static int unpack_meta_aggregation_type(mpack_reader_t *reader, size_t index, vo
     result = cmt_mpack_consume_uint_tag(reader, &value);
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
+        if (value != CMT_AGGREGATION_TYPE_UNSPECIFIED &&
+            value != CMT_AGGREGATION_TYPE_DELTA &&
+            value != CMT_AGGREGATION_TYPE_CUMULATIVE) {
+            return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+        }
+
         decode_context->aggregation_type = value;
     }
 
@@ -1346,6 +1491,7 @@ static int unpack_meta_aggregation_type(mpack_reader_t *reader, size_t index, vo
 static int unpack_meta_opts(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
+    struct cmt_opts                   *opts;
 
     if (NULL == reader ||
         NULL == context) {
@@ -1353,6 +1499,15 @@ static int unpack_meta_opts(mpack_reader_t *reader, size_t index, void *context)
     }
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
+    opts = decode_context->map->opts;
+    if (opts == NULL ||
+        opts->ns != NULL ||
+        opts->subsystem != NULL ||
+        opts->name != NULL ||
+        opts->description != NULL ||
+        decode_context->map->unit != NULL) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
 
     return unpack_opts(reader, decode_context->map);
 }
@@ -1505,9 +1660,13 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
     result = cmt_mpack_unpack_map(reader, callbacks, context);
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
-	if (decode_context->map == NULL || decode_context->map->parent == NULL) {
+        if (decode_context->map == NULL ||
+            decode_context->map->parent == NULL ||
+            decode_context->map->opts == NULL ||
+            decode_context->map->opts->name == NULL ||
+            decode_context->map->opts->description == NULL) {
             return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
-	}
+        }
 
         decode_context->map->label_count = cfl_list_size(&decode_context->map->label_keys);
         if (decode_context->map->type == CMT_HISTOGRAM) {
@@ -1994,6 +2153,8 @@ int cmt_decode_msgpack_create(struct cmt **out_cmt, char *in_buf, size_t in_size
         in_size < *offset ) {
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
+
+    *out_cmt = NULL;
 
     if (0 == in_size ||
         0 == (in_size - *offset) ) {

--- a/src/cmt_decode_opentelemetry.c
+++ b/src/cmt_decode_opentelemetry.c
@@ -32,6 +32,8 @@
 
 #include <math.h>
 #include <inttypes.h>
+#include <stdint.h>
+#include <limits.h>
 
 static struct cfl_variant *clone_variant(Opentelemetry__Proto__Common__V1__AnyValue *source);
 
@@ -263,25 +265,23 @@ static struct cmt_map_label *create_label(char *caption, size_t length)
 {
     struct cmt_map_label *instance;
 
-    if (caption == NULL) {
-        return NULL;
-    }
-
     instance = calloc(1, sizeof(struct cmt_map_label));
 
     if (instance != NULL) {
-        if (length == (size_t) -1) {
-            length = strlen(caption);
-        }
+        if (caption != NULL) {
+            if (length == (size_t) -1) {
+                length = strlen(caption);
+            }
 
-        instance->name = cfl_sds_create_len(caption, length);
+            instance->name = cfl_sds_create_len(caption, length);
 
-        if (instance->name == NULL) {
-            cmt_errno();
+            if (instance->name == NULL) {
+                cmt_errno();
 
-            free(instance);
+                free(instance);
 
-            instance = NULL;
+                instance = NULL;
+            }
         }
     }
 
@@ -573,6 +573,7 @@ static int decode_data_point_labels(struct cmt *cmt,
 {
     char                                        dummy_label_value[32];
     void                                      **value_index_list;
+    size_t                                      alloc_count;
     size_t                                      attribute_index;
     size_t                                      map_label_index;
     size_t                                      map_label_count;
@@ -589,11 +590,17 @@ static int decode_data_point_labels(struct cmt *cmt,
         return result;
     }
 
-    if (attribute_count > 127) {
+    if (attribute_list == NULL) {
         return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
     }
 
-    value_index_list = calloc(128, sizeof(void *));
+    map_label_count = cfl_list_size(&map->label_keys);
+    if (attribute_count > SIZE_MAX - map_label_count) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
+    alloc_count = map_label_count + attribute_count;
+    value_index_list = calloc(alloc_count, sizeof(void *));
 
     if (value_index_list == NULL) {
         return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
@@ -631,6 +638,11 @@ static int decode_data_point_labels(struct cmt *cmt,
         }
 
         if (result == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
+            if (label_index >= alloc_count) {
+                result = CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+                break;
+            }
+
             value_index_list[label_index] = (void *) attribute;
         }
     }
@@ -642,24 +654,33 @@ static int decode_data_point_labels(struct cmt *cmt,
          map_label_index < map_label_count ;
          map_label_index++) {
 
+        if (map_label_index >= alloc_count) {
+            result = CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+            break;
+        }
+
         if (value_index_list[map_label_index] != NULL) {
             attribute = (Opentelemetry__Proto__Common__V1__KeyValue *)
                             value_index_list[map_label_index];
 
             if (attribute->value == NULL) {
-                result = append_new_metric_label_value(metric, "", 0);
+                result = append_new_metric_label_value(metric, NULL, 0);
                 continue;
             }
 
             if (attribute->value->value_case == OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE) {
-                result = append_new_metric_label_value(metric,
-                                                       attribute->value->string_value != NULL ?
-                                                       attribute->value->string_value : "",
-                                                       (size_t) -1);
+                if (attribute->value->string_value == NULL) {
+                    result = append_new_metric_label_value(metric, NULL, 0);
+                }
+                else {
+                    result = append_new_metric_label_value(metric,
+                                                           attribute->value->string_value,
+                                                           (size_t) -1);
+                }
             }
             else if (attribute->value->value_case ==
                      OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE_STRINDEX) {
-                result = append_new_metric_label_value(metric, "", 0);
+                result = append_new_metric_label_value(metric, NULL, 0);
             }
             else if (attribute->value->value_case == OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_BYTES_VALUE) {
                 if (attribute->value->bytes_value.data == NULL &&
@@ -689,11 +710,11 @@ static int decode_data_point_labels(struct cmt *cmt,
                 result = append_new_metric_label_value(metric, dummy_label_value, (size_t) -1);
             }
             else {
-                result = append_new_metric_label_value(metric, "", 0);
+                result = append_new_metric_label_value(metric, NULL, 0);
             }
         }
         else {
-            result = append_new_metric_label_value(metric, "", 0);
+            result = append_new_metric_label_value(metric, NULL, 0);
         }
     }
 
@@ -810,9 +831,17 @@ static int decode_numerical_data_point_list(struct cmt *cmt,
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (data_point_count > 0 && data_point_list == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0 ;
          result == 0 &&
          index < data_point_count ; index++) {
+        if (data_point_list[index] == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         result = decode_numerical_data_point(cmt, map, data_point_list[index]);
     }
 
@@ -833,6 +862,10 @@ static int decode_summary_data_point(struct cmt *cmt,
 
     summary = (struct cmt_summary *) map->parent;
 
+    if (data_point->n_quantile_values > 0 && data_point->quantile_values == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     if (summary->quantiles == NULL) {
         summary->quantiles = calloc(data_point->n_quantile_values,
                                     sizeof(double));
@@ -846,6 +879,10 @@ static int decode_summary_data_point(struct cmt *cmt,
         for (index = 0 ;
              index < data_point->n_quantile_values ;
              index++) {
+            if (data_point->quantile_values[index] == NULL) {
+                return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+            }
+
             summary->quantiles[index] = data_point->quantile_values[index]->quantile;
         }
     }
@@ -943,9 +980,17 @@ static int decode_summary_data_point_list(struct cmt *cmt,
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (data_point_count > 0 && data_point_list == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0 ;
          result == CMT_DECODE_OPENTELEMETRY_SUCCESS &&
          index < data_point_count ; index++) {
+        if (data_point_list[index] == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         result = decode_summary_data_point(cmt, map, data_point_list[index]);
     }
 
@@ -965,6 +1010,18 @@ static int decode_histogram_data_point(struct cmt *cmt,
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
     histogram = (struct cmt_histogram *) map->parent;
+
+    if (data_point->n_explicit_bounds > 0 && data_point->explicit_bounds == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (data_point->n_bucket_counts > 0 && data_point->bucket_counts == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (data_point->n_bucket_counts > INT_MAX) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
 
     if (data_point->n_bucket_counts > data_point->n_explicit_bounds + 1) {
         return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
@@ -1023,6 +1080,10 @@ static int decode_histogram_data_point(struct cmt *cmt,
         struct cfl_kvlist *point_metadata;
 
         if (sample->hist_buckets == NULL) {
+            if (data_point->n_bucket_counts == SIZE_MAX) {
+                return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+            }
+
             sample->hist_buckets = calloc(data_point->n_bucket_counts + 1,
                                           sizeof(uint64_t));
 
@@ -1080,9 +1141,17 @@ static int decode_histogram_data_point_list(struct cmt *cmt,
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (data_point_count > 0 && data_point_list == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0 ;
          result == 0 &&
          index < data_point_count ; index++) {
+        if (data_point_list[index] == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         result = decode_histogram_data_point(cmt, map, data_point_list[index]);
     }
 
@@ -1221,6 +1290,18 @@ static int decode_exponential_histogram_data_point(struct cmt *cmt,
     new_positive_buckets = NULL;
     new_negative_buckets = NULL;
 
+    if (positive != NULL &&
+        positive->n_bucket_counts > 0 &&
+        positive->bucket_counts == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (negative != NULL &&
+        negative->n_bucket_counts > 0 &&
+        negative->bucket_counts == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     static_metric_detected = CMT_FALSE;
 
     if (data_point->n_attributes == 0) {
@@ -1354,10 +1435,18 @@ static int decode_exponential_histogram_data_point_list(
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (data_point_count > 0 && data_point_list == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0 ;
          result == CMT_DECODE_OPENTELEMETRY_SUCCESS &&
          index < data_point_count ;
          index++) {
+        if (data_point_list[index] == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         result = decode_exponential_histogram_data_point(cmt, map, data_point_list[index]);
     }
 
@@ -1409,6 +1498,10 @@ static int decode_metrics_entry(struct cmt *cmt,
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (metric == NULL || metric->name == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     metric_name = metric->name;
     metric_unit = metric->unit;
     metric_namespace = "";
@@ -1423,6 +1516,10 @@ static int decode_metrics_entry(struct cmt *cmt,
     }
 
     if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM) {
+        if (metric->sum == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         instance = cmt_counter_create(cmt,
                                       metric_namespace,
                                       metric_subsystem,
@@ -1463,6 +1560,10 @@ static int decode_metrics_entry(struct cmt *cmt,
         }
     }
     else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
+        if (metric->gauge == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         instance = cmt_gauge_create(cmt,
                                     metric_namespace,
                                     metric_subsystem,
@@ -1503,6 +1604,10 @@ static int decode_metrics_entry(struct cmt *cmt,
         }
     }
     else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY) {
+        if (metric->summary == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         instance = cmt_summary_create(cmt,
                                       metric_namespace,
                                       metric_subsystem,
@@ -1548,6 +1653,10 @@ static int decode_metrics_entry(struct cmt *cmt,
         }
     }
     else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM) {
+        if (metric->histogram == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         instance = cmt_histogram_create(cmt,
                                         metric_namespace,
                                         metric_subsystem,
@@ -1589,6 +1698,10 @@ static int decode_metrics_entry(struct cmt *cmt,
         }
     }
     else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_EXPONENTIAL_HISTOGRAM) {
+        if (metric->exponential_histogram == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         instance = cmt_exp_histogram_create(cmt,
                                             metric_namespace,
                                             metric_subsystem,
@@ -1629,6 +1742,9 @@ static int decode_metrics_entry(struct cmt *cmt,
                 }
             }
         }
+    }
+    else {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
     }
 
     return result;
@@ -1743,6 +1859,10 @@ static int decode_scope_metrics_entry(struct cfl_list *context_list,
     int         result;
     size_t      index;
 
+    if (metrics == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     context = cmt_create();
 
     if (context == NULL) {
@@ -1779,6 +1899,10 @@ static int decode_scope_metrics_entry(struct cfl_list *context_list,
 
     if (result != CMT_DECODE_OPENTELEMETRY_SUCCESS) {
         return result;
+    }
+
+    if (metrics->n_metrics > 0 && metrics->metrics == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
     }
 
     for (index = 0 ;
@@ -1889,6 +2013,15 @@ static int decode_resource_metrics_entry(
 
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
+    if (resource_metrics == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (resource_metrics->n_scope_metrics > 0 &&
+        resource_metrics->scope_metrics == NULL) {
+        return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0 ;
          result == CMT_DECODE_OPENTELEMETRY_SUCCESS &&
          index < resource_metrics->n_scope_metrics ;
@@ -1948,6 +2081,10 @@ static int decode_service_request(struct cfl_list *context_list,
     result = CMT_DECODE_OPENTELEMETRY_SUCCESS;
 
     if (service_request->n_resource_metrics > 0) {
+        if (service_request->resource_metrics == NULL) {
+            return CMT_DECODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         for (index = 0 ;
              result == CMT_DECODE_OPENTELEMETRY_SUCCESS &&
              index < service_request->n_resource_metrics ;

--- a/src/cmt_decode_prometheus_remote_write.c
+++ b/src/cmt_decode_prometheus_remote_write.c
@@ -26,6 +26,9 @@
 #include <cmetrics/cmt_untyped.h>
 #include <cmetrics/cmt_decode_prometheus_remote_write.h>
 
+#include <stdint.h>
+#include <limits.h>
+
 static void *__cmt_allocator_alloc(void *data, size_t size) {
     return malloc(size);
 }
@@ -140,6 +143,7 @@ static int decode_labels(struct cmt *cmt,
                          Prometheus__Label **labels)
 {
     void                 **value_index_list;
+    size_t                 alloc_count;
     size_t                 prom_label_index;
     size_t                 map_label_index;
     size_t                 map_label_count;
@@ -156,11 +160,17 @@ static int decode_labels(struct cmt *cmt,
         return result;
     }
 
-    if (n_labels > 127) {
+    if (labels == NULL) {
         return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
     }
 
-    value_index_list = calloc(128, sizeof(void *));
+    map_label_count = cfl_list_size(&map->label_keys);
+    if (n_labels > SIZE_MAX - map_label_count) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    alloc_count = map_label_count + n_labels;
+    value_index_list = calloc(alloc_count, sizeof(void *));
 
     if (value_index_list == NULL) {
         return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
@@ -198,6 +208,11 @@ static int decode_labels(struct cmt *cmt,
         }
 
         if (result == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+            if (label_index >= alloc_count) {
+                result = CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+                break;
+            }
+
             value_index_list[label_index] = (void *) label;
         }
     }
@@ -208,6 +223,11 @@ static int decode_labels(struct cmt *cmt,
          result == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS &&
          map_label_index < map_label_count ;
          map_label_index++) {
+
+        if (map_label_index >= alloc_count) {
+            result = CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+            break;
+        }
 
         if (value_index_list[map_label_index] != NULL) {
             label = (Prometheus__Label *) value_index_list[map_label_index];
@@ -391,10 +411,35 @@ static int decode_histogram_points(struct cmt *cmt,
 
     histogram = (struct cmt_histogram *) map->parent;
 
+    if (hist == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (hist->n_negative_spans > 0 && hist->negative_spans == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (hist->n_positive_spans > 0 && hist->positive_spans == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (hist->n_negative_counts > 0 && hist->negative_counts == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (hist->n_positive_counts > 0 && hist->positive_counts == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (hist->n_negative_counts > INT_MAX ||
+        hist->n_positive_counts > INT_MAX) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
     if (histogram->buckets == NULL) {
         if (hist->n_negative_spans > 0) {
             count_size = hist->n_negative_counts;
-            spans = calloc(1, sizeof(double) * count_size);
+            spans = calloc(count_size, sizeof(double));
             if (spans == NULL) {
                 return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
             }
@@ -402,6 +447,11 @@ static int decode_histogram_points(struct cmt *cmt,
             bucket_index = 0;
             count_index = 0;
             for (span_index = 0; span_index < hist->n_negative_spans; span_index++) {
+                if (hist->negative_spans[span_index] == NULL) {
+                    free(spans);
+                    return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+                }
+
                 bucket_index += hist->negative_spans[span_index]->offset;
 
                 for (i = 0; i < hist->negative_spans[span_index]->length; i++) {
@@ -419,7 +469,7 @@ static int decode_histogram_points(struct cmt *cmt,
         }
         else if (hist->n_positive_spans > 0) {
             count_size = hist->n_positive_counts;
-            spans = calloc(1, sizeof(double) * count_size);
+            spans = calloc(count_size, sizeof(double));
             if (spans == NULL) {
                 return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_ALLOCATION_ERROR;
             }
@@ -427,6 +477,11 @@ static int decode_histogram_points(struct cmt *cmt,
             bucket_index = 0;
             count_index = 0;
             for (span_index = 0; span_index < hist->n_positive_spans; span_index++) {
+                if (hist->positive_spans[span_index] == NULL) {
+                    free(spans);
+                    return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+                }
+
                 bucket_index += hist->positive_spans[span_index]->offset;
 
                 for (i = 0; i < hist->positive_spans[span_index]->length; i++) {
@@ -487,8 +542,20 @@ static int decode_histogram_points(struct cmt *cmt,
     }
 
     if (metric->hist_buckets == NULL) {
-        metric->hist_buckets = calloc(1, sizeof(uint64_t) *
-                                      (histogram->buckets->count + 1));
+        if (histogram->buckets->count >= INT_MAX) {
+            if (static_metric_detected == CMT_FALSE) {
+                destroy_label_list(&metric->labels);
+
+                cfl_list_del(&metric->_head);
+
+                free(metric);
+            }
+
+            return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+        }
+
+        metric->hist_buckets = calloc(histogram->buckets->count + 1,
+                                      sizeof(uint64_t));
         if (metric->hist_buckets == NULL) {
             if (static_metric_detected == CMT_FALSE) {
                 if (metric->hist_buckets != NULL) {
@@ -575,6 +642,10 @@ static int decode_histogram_time_series(struct cmt *cmt,
 
     result = CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
 
+    if (hist_count > 0 && ts->histograms == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
     for (index = 0; result == 0 && index < hist_count; index++) {
         histogram = ts->histograms[index];
         result = decode_histogram_points(cmt, map,
@@ -612,6 +683,7 @@ static int decode_metrics_entry(struct cmt *cmt,
                                 Prometheus__WriteRequest *write)
 {
     int   i;
+    int   j;
     char *metric_name = NULL;
     char *metric_subsystem   = NULL;
     char *metric_namespace   = NULL;
@@ -628,6 +700,14 @@ static int decode_metrics_entry(struct cmt *cmt,
     result = CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
 
     ts_count = write->n_timeseries;
+    if (ts_count > 0 && write->timeseries == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (write->n_metadata > 0 && write->metadata == NULL) {
+        return CMT_DECODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+    }
+
     for (i = 0; i < ts_count; i++) {
         ts = write->timeseries[i];
         if (ts == NULL) {
@@ -637,28 +717,41 @@ static int decode_metrics_entry(struct cmt *cmt,
         meta_count = write->n_metadata;
         hist_count = ts->n_histograms;
         metadata = NULL;
-        if (meta_count > i) {
-            metadata = write->metadata[i];
+
+        metric_name = cmt_metric_name_from_labels(ts);
+        if (metric_name == NULL) {
+            continue;
         }
+
+        for (j = 0; j < meta_count; j++) {
+            if (write->metadata[j] == NULL ||
+                write->metadata[j]->metric_family_name == NULL) {
+                continue;
+            }
+
+            if (strcmp(write->metadata[j]->metric_family_name, metric_name) == 0) {
+                metadata = write->metadata[j];
+                break;
+            }
+        }
+
         if (hist_count > 0) {
             type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__HISTOGRAM;
-            metric_description = "-";
+            metric_description = metadata != NULL ? metadata->help : "-";
+            if (metric_description == NULL) {
+                metric_description = "-";
+            }
         }
         else if (metadata == NULL) {
             type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__GAUGE;
             metric_description = "-";
         }
         else {
-            type = write->metadata[i]->type;
-            metric_description = write->metadata[i]->help;
+            type = metadata->type;
+            metric_description = metadata->help;
             if (metric_description == NULL) {
                 metric_description = "-";
             }
-        }
-
-        metric_name = cmt_metric_name_from_labels(ts);
-        if (metric_name == NULL) {
-            continue;
         }
 
         metric_namespace = "";

--- a/src/cmt_encode_influx.c
+++ b/src/cmt_encode_influx.c
@@ -283,6 +283,12 @@ static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
         return;
     }
 
+    n = cfl_list_size(&metric->labels);
+    label_key_count = map->label_count;
+    if (n > label_key_count) {
+        return;
+    }
+
     opts = map->opts;
 
     /* Measurement */
@@ -324,17 +330,11 @@ static void format_metric(struct cmt *cmt, cfl_sds_t *buf, struct cmt_map *map,
     }
 
     /* Labels / Tags */
-    n = cfl_list_size(&metric->labels);
-    label_key_count = map->label_count;
     if (n > 0 && label_key_count > 0) {
         label_k = cfl_list_entry_first(&map->label_keys, struct cmt_map_label, _head);
 
         label_index = 0;
         cfl_list_foreach(head, &metric->labels) {
-            if (label_index >= label_key_count) {
-                break;
-            }
-
             label_v = cfl_list_entry(head, struct cmt_map_label, _head);
 
             if (label_k->name == NULL || label_v->name == NULL) {

--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -3197,9 +3197,18 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     struct cfl_list                                     *head;
     size_t                                              label_name_count;
     size_t                                              label_name_index;
+    size_t                                              sample_label_count;
+
+    sample_label_count = 0;
+    cfl_list_foreach(head, &sample->labels) {
+        label_value = cfl_list_entry(head, struct cmt_map_label, _head);
+        if (label_value->name != NULL) {
+            sample_label_count++;
+        }
+    }
 
     attribute_count = cfl_list_size(&context->cmt->static_labels->list) +
-                      cfl_list_size(&sample->labels);
+                      sample_label_count;
     start_timestamp = 0;
 
     if (cmt_metric_has_start_timestamp(sample)) {
@@ -3364,7 +3373,7 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     }
 
     label_name_count = map->label_count;
-    if (cfl_list_size(&sample->labels) > label_name_count) {
+    if (sample_label_count > label_name_count) {
         destroy_data_point(data_point, map->type);
 
         return CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
@@ -3378,6 +3387,23 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     cfl_list_foreach(head, &sample->labels) {
         label_value = cfl_list_entry(head, struct cmt_map_label, _head);
 
+        if (label_value->name == NULL) {
+            label_name_index++;
+            if (label_name_index < label_name_count) {
+                label_name = cfl_list_entry_next(&label_name->_head,
+                                                 struct cmt_map_label,
+                                                 _head, &map->label_keys);
+            }
+
+            continue;
+        }
+
+        if (label_name_index >= label_name_count) {
+            destroy_data_point(data_point, map->type);
+
+            return CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
+        }
+
         if (label_name->name == NULL) {
             destroy_data_point(data_point, map->type);
 
@@ -3385,8 +3411,7 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
         }
 
         attribute = initialize_string_attribute(label_name->name,
-                                                label_value->name != NULL ?
-                                                label_value->name : "");
+                                                label_value->name);
 
         if (attribute == NULL) {
             destroy_data_point(data_point, map->type);

--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -273,11 +273,16 @@ static int initialize_temporary_metric(struct cmt_metric *destination,
             return -1;
         }
 
-        destination_label->name = cfl_sds_create(source_label->name);
-        if (destination_label->name == NULL) {
-            free(destination_label);
-            destroy_temporary_metric_labels(destination);
-            return -1;
+        if (source_label->name == NULL) {
+            destination_label->name = NULL;
+        }
+        else {
+            destination_label->name = cfl_sds_create(source_label->name);
+            if (destination_label->name == NULL) {
+                free(destination_label);
+                destroy_temporary_metric_labels(destination);
+                return -1;
+            }
         }
 
         cfl_list_add(&destination_label->_head, &destination->labels);
@@ -324,8 +329,7 @@ static void format_metric(struct cmt *cmt,
 
         label_v = cfl_list_entry(head, struct cmt_map_label, _head);
         if (label_k->name != NULL &&
-            label_v->name != NULL &&
-            strlen(label_v->name)) {
+            label_v->name != NULL) {
             defined_labels++;
         }
 
@@ -363,8 +367,7 @@ static void format_metric(struct cmt *cmt,
             label_v = cfl_list_entry(head, struct cmt_map_label, _head);
 
             if (label_k->name != NULL &&
-                label_v->name != NULL &&
-                strlen(label_v->name)) {
+                label_v->name != NULL) {
                 fmt->labels_count += add_label(buf, label_k->name, label_v->name);
                 if (i < defined_labels) {
                     cfl_sds_cat_safe(buf, ",", 1);

--- a/src/cmt_encode_prometheus_remote_write.c
+++ b/src/cmt_encode_prometheus_remote_write.c
@@ -373,6 +373,7 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
     size_t                             label_index;
     size_t                             label_count;
     size_t                             metric_label_count;
+    size_t                             metric_label_emit_count;
     struct cmt_map_label              *label_value;
     struct cmt_map_label              *label_name;
     Prometheus__Label                **label_list;
@@ -417,8 +418,16 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
      * one for the fixed __name__ label
      */
     metric_label_count = cfl_list_size(&metric->labels);
+    metric_label_emit_count = 0;
+    cfl_list_foreach(head, &metric->labels) {
+        label_value = cfl_list_entry(head, struct cmt_map_label, _head);
+        if (label_value->name != NULL) {
+            metric_label_emit_count++;
+        }
+    }
+
     label_count = cfl_list_size(&context->cmt->static_labels->list) +
-                  metric_label_count +
+                  metric_label_emit_count +
                   1;
 
 
@@ -517,6 +526,22 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
 
             label_value = cfl_list_entry(head, struct cmt_map_label, _head);
 
+            if (label_value->name == NULL) {
+                label_name_index++;
+                if (label_name_index < label_name_count) {
+                    label_name = cfl_list_entry_next(&label_name->_head,
+                                                     struct cmt_map_label,
+                                                     _head, &map->label_keys);
+                }
+
+                continue;
+            }
+
+            if (label_name_index >= label_name_count) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
+                break;
+            }
+
             if (label_name->name == NULL) {
                 result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_INVALID_ARGUMENT_ERROR;
                 break;
@@ -525,8 +550,7 @@ int set_up_time_series_for_label_set(struct cmt_prometheus_remote_write_context 
             result = append_entry_to_prometheus_label_list(label_list,
                                                            &label_index,
                                                            label_name->name,
-                                                           label_value->name != NULL ?
-                                                           label_value->name : "");
+                                                           label_value->name);
 
             if (result != CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS)
             {

--- a/src/cmt_encode_splunk_hec.c
+++ b/src/cmt_encode_splunk_hec.c
@@ -89,11 +89,16 @@ static int initialize_temporary_metric(struct cmt_metric *destination,
             return -1;
         }
 
-        destination_label->name = cfl_sds_create(source_label->name);
-        if (destination_label->name == NULL) {
-            free(destination_label);
-            destroy_temporary_metric_labels(destination);
-            return -1;
+        if (source_label->name == NULL) {
+            destination_label->name = NULL;
+        }
+        else {
+            destination_label->name = cfl_sds_create(source_label->name);
+            if (destination_label->name == NULL) {
+                free(destination_label);
+                destroy_temporary_metric_labels(destination);
+                return -1;
+            }
         }
 
         cfl_list_add(&destination_label->_head, &destination->labels);

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -120,11 +120,16 @@ static struct cmt_metric *map_metric_create(uint64_t hash,
         }
 
         name = labels_val[i];
-        label->name = cfl_sds_create(name);
-        if (!label->name) {
-            cmt_errno();
-            free(label);
-            goto error;
+        if (name == NULL) {
+            label->name = NULL;
+        }
+        else {
+            label->name = cfl_sds_create(name);
+            if (!label->name) {
+                cmt_errno();
+                free(label);
+                goto error;
+            }
         }
         cfl_list_add(&label->_head, &metric->labels);
     }

--- a/tests/decoding.c
+++ b/tests/decoding.c
@@ -18,6 +18,8 @@
  */
 
 #include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_metric.h>
@@ -67,6 +69,82 @@ static cfl_sds_t generate_remote_write_payload(char *extra_label_name,
 
     time_series_list[0] = &time_series;
     request.n_timeseries = 1;
+    request.timeseries = time_series_list;
+
+    payload_size = prometheus__write_request__get_packed_size(&request);
+    packed_payload = calloc(1, payload_size);
+    if (packed_payload == NULL) {
+        return NULL;
+    }
+
+    prometheus__write_request__pack(&request, packed_payload);
+    payload = cfl_sds_create_len((char *) packed_payload, payload_size);
+    free(packed_payload);
+
+    return payload;
+}
+
+static cfl_sds_t generate_remote_write_out_of_order_metadata_payload()
+{
+    Prometheus__WriteRequest request;
+    Prometheus__MetricMetadata metadata;
+    Prometheus__TimeSeries gauge_series;
+    Prometheus__TimeSeries counter_series;
+    Prometheus__Label gauge_name_label;
+    Prometheus__Label counter_name_label;
+    Prometheus__Sample gauge_sample;
+    Prometheus__Sample counter_sample;
+    Prometheus__MetricMetadata *metadata_list[1];
+    Prometheus__TimeSeries *time_series_list[2];
+    Prometheus__Label *gauge_label_list[1];
+    Prometheus__Label *counter_label_list[1];
+    Prometheus__Sample *gauge_sample_list[1];
+    Prometheus__Sample *counter_sample_list[1];
+    size_t payload_size;
+    unsigned char *packed_payload;
+    cfl_sds_t payload;
+
+    prometheus__write_request__init(&request);
+    prometheus__metric_metadata__init(&metadata);
+    prometheus__time_series__init(&gauge_series);
+    prometheus__time_series__init(&counter_series);
+    prometheus__label__init(&gauge_name_label);
+    prometheus__label__init(&counter_name_label);
+    prometheus__sample__init(&gauge_sample);
+    prometheus__sample__init(&counter_sample);
+
+    metadata.type = PROMETHEUS__METRIC_METADATA__METRIC_TYPE__COUNTER;
+    metadata.metric_family_name = "rw_counter";
+    metadata.help = "remote write counter";
+    metadata_list[0] = &metadata;
+    request.n_metadata = 1;
+    request.metadata = metadata_list;
+
+    gauge_name_label.name = "__name__";
+    gauge_name_label.value = "rw_gauge";
+    gauge_label_list[0] = &gauge_name_label;
+    gauge_series.n_labels = 1;
+    gauge_series.labels = gauge_label_list;
+    gauge_sample.value = 1.0;
+    gauge_sample.timestamp = 123;
+    gauge_sample_list[0] = &gauge_sample;
+    gauge_series.n_samples = 1;
+    gauge_series.samples = gauge_sample_list;
+
+    counter_name_label.name = "__name__";
+    counter_name_label.value = "rw_counter";
+    counter_label_list[0] = &counter_name_label;
+    counter_series.n_labels = 1;
+    counter_series.labels = counter_label_list;
+    counter_sample.value = 2.0;
+    counter_sample.timestamp = 124;
+    counter_sample_list[0] = &counter_sample;
+    counter_series.n_samples = 1;
+    counter_series.samples = counter_sample_list;
+
+    time_series_list[0] = &gauge_series;
+    time_series_list[1] = &counter_series;
+    request.n_timeseries = 2;
     request.timeseries = time_series_list;
 
     payload_size = prometheus__write_request__get_packed_size(&request);
@@ -291,6 +369,45 @@ void test_prometheus_remote_write_sparse_metadata_histogram()
     }
 }
 
+void test_prometheus_remote_write_metadata_matched_by_name()
+{
+    int ret;
+    struct cmt *decoded_context = NULL;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    cfl_sds_t payload;
+
+    cmt_initialize();
+
+    payload = generate_remote_write_out_of_order_metadata_payload();
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        ret = cmt_decode_prometheus_remote_write_create(&decoded_context,
+                                                        payload,
+                                                        cfl_sds_len(payload));
+        TEST_CHECK(ret == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS);
+        if (ret == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+            TEST_CHECK(cfl_list_size(&decoded_context->gauges) == 1);
+            TEST_CHECK(cfl_list_size(&decoded_context->counters) == 1);
+
+            gauge = cfl_list_entry_first(&decoded_context->gauges,
+                                         struct cmt_gauge, _head);
+            counter = cfl_list_entry_first(&decoded_context->counters,
+                                           struct cmt_counter, _head);
+            TEST_CHECK(gauge != NULL);
+            TEST_CHECK(counter != NULL);
+            if (gauge != NULL) {
+                TEST_CHECK(strcmp(gauge->opts.name, "rw_gauge") == 0);
+            }
+            if (counter != NULL) {
+                TEST_CHECK(strcmp(counter->opts.name, "rw_counter") == 0);
+            }
+            cmt_decode_prometheus_remote_write_destroy(decoded_context);
+        }
+        cfl_sds_destroy(payload);
+    }
+}
+
 void test_statsd()
 {
     int ret;
@@ -327,6 +444,7 @@ TEST_LIST = {
     {"prometheus_remote_write_missing_label_name_rejected", test_prometheus_remote_write_missing_label_name_rejected},
     {"prometheus_remote_write_missing_label_value_no_crash", test_prometheus_remote_write_missing_label_value_no_crash},
     {"prometheus_remote_write_sparse_metadata_histogram", test_prometheus_remote_write_sparse_metadata_histogram},
+    {"prometheus_remote_write_metadata_matched_by_name", test_prometheus_remote_write_metadata_matched_by_name},
     {"statsd", test_statsd},
     { 0 }
 };

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -25,6 +25,7 @@
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_summary.h>
 #include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
@@ -35,6 +36,9 @@
 #include <cmetrics/cmt_encode_influx.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
 #include <cmetrics/cmt_encode_cloudwatch_emf.h>
+
+#include <limits.h>
+#include <mpack/mpack.h>
 
 #include "cmt_tests.h"
 
@@ -331,6 +335,336 @@ void test_cmt_to_msgpack_cleanup_on_error()
     TEST_CHECK(cmt2 == NULL);
 
 #endif
+}
+
+enum malformed_msgpack_payload {
+    MSGPACK_MALFORMED_DUPLICATE_TYPE,
+    MSGPACK_MALFORMED_INVALID_AGGREGATION_TYPE,
+    MSGPACK_MALFORMED_INVALID_VALUE_TYPE,
+    MSGPACK_MALFORMED_MISSING_NAME,
+    MSGPACK_MALFORMED_MISSING_DESCRIPTION,
+    MSGPACK_MALFORMED_EXP_HIST_SCALE_OVERFLOW
+};
+
+static void pack_msgpack_context_meta(mpack_writer_t *writer)
+{
+    mpack_write_cstr(writer, "meta");
+    mpack_start_map(writer, 3);
+
+    mpack_write_cstr(writer, "cmetrics");
+    mpack_start_map(writer, 0);
+    mpack_finish_map(writer);
+
+    mpack_write_cstr(writer, "external");
+    mpack_start_map(writer, 0);
+    mpack_finish_map(writer);
+
+    mpack_write_cstr(writer, "processing");
+    mpack_start_map(writer, 1);
+    mpack_write_cstr(writer, "static_labels");
+    mpack_start_array(writer, 0);
+    mpack_finish_array(writer);
+    mpack_finish_map(writer);
+
+    mpack_finish_map(writer);
+}
+
+static void pack_msgpack_opts(mpack_writer_t *writer, int include_name)
+{
+    mpack_start_map(writer, include_name ? 5 : 4);
+
+    mpack_write_cstr(writer, "ns");
+    mpack_write_cstr(writer, "test");
+    mpack_write_cstr(writer, "ss");
+    mpack_write_cstr(writer, "msgpack");
+
+    if (include_name) {
+        mpack_write_cstr(writer, "name");
+        mpack_write_cstr(writer, "malformed");
+    }
+
+    mpack_write_cstr(writer, "desc");
+    mpack_write_cstr(writer, "malformed msgpack");
+    mpack_write_cstr(writer, "unit");
+    mpack_write_cstr(writer, "");
+
+    mpack_finish_map(writer);
+}
+
+static void pack_msgpack_opts_without_description(mpack_writer_t *writer)
+{
+    mpack_start_map(writer, 4);
+
+    mpack_write_cstr(writer, "ns");
+    mpack_write_cstr(writer, "test");
+    mpack_write_cstr(writer, "ss");
+    mpack_write_cstr(writer, "msgpack");
+    mpack_write_cstr(writer, "name");
+    mpack_write_cstr(writer, "malformed");
+    mpack_write_cstr(writer, "unit");
+    mpack_write_cstr(writer, "");
+
+    mpack_finish_map(writer);
+}
+
+static void pack_msgpack_basic_meta(mpack_writer_t *writer,
+                                    enum malformed_msgpack_payload payload_type)
+{
+    int include_name;
+
+    include_name = (payload_type != MSGPACK_MALFORMED_MISSING_NAME);
+
+    mpack_write_cstr(writer, "meta");
+
+    if (payload_type == MSGPACK_MALFORMED_DUPLICATE_TYPE) {
+        mpack_start_map(writer, 5);
+
+        mpack_write_cstr(writer, "ver");
+        mpack_write_uint(writer, MSGPACK_ENCODER_VERSION);
+        mpack_write_cstr(writer, "type");
+        mpack_write_uint(writer, CMT_COUNTER);
+        mpack_write_cstr(writer, "type");
+        mpack_write_uint(writer, CMT_GAUGE);
+    }
+    else {
+        mpack_start_map(writer, 4);
+
+        mpack_write_cstr(writer, "ver");
+        mpack_write_uint(writer, MSGPACK_ENCODER_VERSION);
+        mpack_write_cstr(writer, "type");
+        if (payload_type == MSGPACK_MALFORMED_EXP_HIST_SCALE_OVERFLOW) {
+            mpack_write_uint(writer, CMT_EXP_HISTOGRAM);
+        }
+        else {
+            mpack_write_uint(writer, CMT_COUNTER);
+        }
+    }
+
+    mpack_write_cstr(writer, "opts");
+    if (payload_type == MSGPACK_MALFORMED_MISSING_DESCRIPTION) {
+        pack_msgpack_opts_without_description(writer);
+    }
+    else {
+        pack_msgpack_opts(writer, include_name);
+    }
+
+    mpack_write_cstr(writer, "labels");
+    mpack_start_array(writer, 0);
+    mpack_finish_array(writer);
+
+    if (payload_type == MSGPACK_MALFORMED_INVALID_AGGREGATION_TYPE) {
+        mpack_write_cstr(writer, "aggregation_type");
+        mpack_write_uint(writer, 127);
+    }
+    else if (payload_type != MSGPACK_MALFORMED_EXP_HIST_SCALE_OVERFLOW) {
+        mpack_write_cstr(writer, "aggregation_type");
+        mpack_write_uint(writer, CMT_AGGREGATION_TYPE_CUMULATIVE);
+    }
+
+    mpack_finish_map(writer);
+}
+
+static void pack_msgpack_basic_value(mpack_writer_t *writer,
+                                     enum malformed_msgpack_payload payload_type)
+{
+    if (payload_type == MSGPACK_MALFORMED_EXP_HIST_SCALE_OVERFLOW) {
+        mpack_start_map(writer, 3);
+        mpack_write_cstr(writer, "ts");
+        mpack_write_uint(writer, 0);
+        mpack_write_cstr(writer, "exp_histogram");
+        mpack_start_map(writer, 10);
+        mpack_write_cstr(writer, "scale");
+        mpack_write_i64(writer, (int64_t) INT_MAX + 1);
+        mpack_write_cstr(writer, "zero_count");
+        mpack_write_uint(writer, 0);
+        mpack_write_cstr(writer, "zero_threshold");
+        mpack_write_double(writer, 0.0);
+        mpack_write_cstr(writer, "positive_offset");
+        mpack_write_int(writer, 0);
+        mpack_write_cstr(writer, "positive_buckets");
+        mpack_start_array(writer, 0);
+        mpack_finish_array(writer);
+        mpack_write_cstr(writer, "negative_offset");
+        mpack_write_int(writer, 0);
+        mpack_write_cstr(writer, "negative_buckets");
+        mpack_start_array(writer, 0);
+        mpack_finish_array(writer);
+        mpack_write_cstr(writer, "count");
+        mpack_write_uint(writer, 0);
+        mpack_write_cstr(writer, "sum_set");
+        mpack_write_uint(writer, 0);
+        mpack_write_cstr(writer, "sum");
+        mpack_write_uint(writer, 0);
+        mpack_finish_map(writer);
+        mpack_write_cstr(writer, "hash");
+        mpack_write_uint(writer, 0);
+        mpack_finish_map(writer);
+
+        return;
+    }
+
+    if (payload_type == MSGPACK_MALFORMED_INVALID_VALUE_TYPE) {
+        mpack_start_map(writer, 5);
+    }
+    else {
+        mpack_start_map(writer, 3);
+    }
+
+    mpack_write_cstr(writer, "ts");
+    mpack_write_uint(writer, 0);
+    mpack_write_cstr(writer, "value");
+    mpack_write_double(writer, 1.0);
+
+    if (payload_type == MSGPACK_MALFORMED_INVALID_VALUE_TYPE) {
+        mpack_write_cstr(writer, "value_type");
+        mpack_write_uint(writer, 127);
+        mpack_write_cstr(writer, "value_int64");
+        mpack_write_i64(writer, 1);
+    }
+
+    mpack_write_cstr(writer, "hash");
+    mpack_write_uint(writer, 0);
+    mpack_finish_map(writer);
+}
+
+static char *generate_malformed_msgpack_payload(size_t *out_size,
+                                                enum malformed_msgpack_payload payload_type)
+{
+    char *data;
+    size_t size;
+    mpack_writer_t writer;
+
+    data = NULL;
+    size = 0;
+
+    mpack_writer_init_growable(&writer, &data, &size);
+
+    mpack_start_map(&writer, 2);
+    pack_msgpack_context_meta(&writer);
+
+    mpack_write_cstr(&writer, "metrics");
+    mpack_start_array(&writer, 1);
+    mpack_start_map(&writer, 2);
+    pack_msgpack_basic_meta(&writer, payload_type);
+    mpack_write_cstr(&writer, "values");
+    mpack_start_array(&writer, 1);
+    pack_msgpack_basic_value(&writer, payload_type);
+    mpack_finish_array(&writer);
+    mpack_finish_map(&writer);
+    mpack_finish_array(&writer);
+    mpack_finish_map(&writer);
+
+    if (mpack_writer_destroy(&writer) != mpack_ok) {
+        return NULL;
+    }
+
+    *out_size = size;
+
+    return data;
+}
+
+static void assert_malformed_msgpack_rejected(enum malformed_msgpack_payload payload_type)
+{
+    int ret;
+    char *payload;
+    size_t offset;
+    size_t payload_size;
+    struct cmt *decoded;
+
+    offset = 0;
+    payload_size = 0;
+    decoded = (struct cmt *) 0x1;
+
+    payload = generate_malformed_msgpack_payload(&payload_size, payload_type);
+    TEST_CHECK(payload != NULL);
+    if (payload == NULL) {
+        return;
+    }
+
+    ret = cmt_decode_msgpack_create(&decoded, payload, payload_size, &offset);
+    TEST_CHECK(ret != CMT_DECODE_MSGPACK_SUCCESS);
+    TEST_CHECK(decoded == NULL);
+
+    cmt_encode_msgpack_destroy(payload);
+}
+
+void test_cmt_msgpack_rejects_malformed_fields()
+{
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_DUPLICATE_TYPE);
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_INVALID_AGGREGATION_TYPE);
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_INVALID_VALUE_TYPE);
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_MISSING_NAME);
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_MISSING_DESCRIPTION);
+    assert_malformed_msgpack_rejected(MSGPACK_MALFORMED_EXP_HIST_SCALE_OVERFLOW);
+}
+
+void test_cmt_msgpack_null_label_roundtrip()
+{
+    int ret;
+    char *mp_buf;
+    size_t mp_size;
+    size_t offset;
+    cfl_sds_t result;
+    struct cmt *cmt1;
+    struct cmt *cmt2;
+    struct cmt_counter *counter;
+
+    mp_buf = NULL;
+    mp_size = 0;
+    offset = 0;
+    result = NULL;
+    cmt2 = NULL;
+
+    cmt1 = cmt_create();
+    TEST_CHECK(cmt1 != NULL);
+    if (cmt1 == NULL) {
+        return;
+    }
+
+    counter = cmt_counter_create(cmt1, "test", "msgpack", "labels",
+                                 "testing msgpack labels",
+                                 3, (char *[]) {"A", "B", "C"});
+    TEST_CHECK(counter != NULL);
+    if (counter == NULL) {
+        cmt_destroy(cmt1);
+        return;
+    }
+
+    cmt_counter_inc(counter, 0, 3, (char *[]) {NULL, "", NULL});
+    cmt_counter_inc(counter, 0, 3, (char *[]) {NULL, "", NULL});
+    cmt_counter_inc(counter, 0, 3, (char *[]) {NULL, "b", NULL});
+    cmt_counter_inc(counter, 0, 3, (char *[]) {"a", "b", "c"});
+
+    ret = cmt_encode_msgpack_create(cmt1, &mp_buf, &mp_size);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cmt_destroy(cmt1);
+        return;
+    }
+
+    ret = cmt_decode_msgpack_create(&cmt2, mp_buf, mp_size, &offset);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(cmt2 != NULL);
+    if (ret == 0 && cmt2 != NULL) {
+        result = cmt_encode_prometheus_create(cmt2, CMT_TRUE);
+        TEST_CHECK(result != NULL);
+
+        if (result != NULL) {
+            TEST_CHECK(strstr(result, "test_msgpack_labels{B=\"\"} 2 0\n") != NULL);
+            TEST_CHECK(strstr(result, "test_msgpack_labels{B=\"b\"} 1 0\n") != NULL);
+            TEST_CHECK(strstr(result, "test_msgpack_labels{A=\"a\",B=\"b\",C=\"c\"} 1 0\n") != NULL);
+            TEST_CHECK(strstr(result, "A=\"\"") == NULL);
+            TEST_CHECK(strstr(result, "C=\"\"") == NULL);
+        }
+    }
+
+    if (result != NULL) {
+        cfl_sds_destroy(result);
+    }
+
+    cmt_destroy(cmt1);
+    cmt_decode_msgpack_destroy(cmt2);
+    cmt_encode_msgpack_destroy(mp_buf);
 }
 
 /*
@@ -1231,6 +1565,8 @@ void test_splunk_hec_summary()
 
 TEST_LIST = {
     {"cmt_msgpack_cleanup_on_error",   test_cmt_to_msgpack_cleanup_on_error},
+    {"cmt_msgpack_rejects_malformed_fields", test_cmt_msgpack_rejects_malformed_fields},
+    {"cmt_msgpack_null_label_roundtrip", test_cmt_msgpack_null_label_roundtrip},
     {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
     {"prometheus_remote_write",        test_prometheus_remote_write},
     {"prometheus_remote_write_old_cmt",test_prometheus_remote_write_with_outdated_timestamps},

--- a/tests/null_label.c
+++ b/tests/null_label.c
@@ -20,6 +20,8 @@
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_encode_influx.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
 
@@ -87,6 +89,8 @@ void test_encoding()
     cfl_sds_t result;
     struct cmt *cmt;
     struct cmt_counter *c;
+    struct cmt_metric *metric;
+    struct cmt_map_label *label;
 
     cmt = cmt_create();
     c = cmt_counter_create(cmt, "test", "dummy", "labels", "testing labels",
@@ -184,6 +188,37 @@ void test_encoding()
         TEST_CHECK(strstr(result, ",}") == NULL);
         TEST_CHECK(strstr(result, "\"B\":\"b\"") != NULL);
         cmt_encode_splunk_hec_destroy(result);
+    }
+
+    cmt_destroy(cmt);
+
+    cmt = cmt_create();
+    c = cmt_counter_create(cmt, "test", "influx", "labels", "testing influx labels",
+                           1, (char *[]) {"A"});
+
+    cmt_counter_inc(c, 0, 1, (char *[]) {"a"});
+    metric = cfl_list_entry_first(&c->map->metrics, struct cmt_metric, _head);
+    TEST_CHECK(metric != NULL);
+    if (metric != NULL) {
+        label = calloc(1, sizeof(struct cmt_map_label));
+        TEST_CHECK(label != NULL);
+        if (label != NULL) {
+            label->name = cfl_sds_create("extra");
+            TEST_CHECK(label->name != NULL);
+            if (label->name != NULL) {
+                cfl_list_add(&label->_head, &metric->labels);
+            }
+            else {
+                free(label);
+            }
+        }
+    }
+
+    result = cmt_encode_influx_create(cmt);
+    TEST_CHECK(result != NULL);
+    if (result != NULL) {
+        TEST_CHECK(cfl_sds_len(result) == 0);
+        cmt_encode_influx_destroy(result);
     }
 
     cmt_destroy(cmt);

--- a/tests/null_label.c
+++ b/tests/null_label.c
@@ -123,6 +123,12 @@ void test_encoding()
     cfl_sds_destroy(result);
 
 
+    cmt_counter_inc(c, 0, 6, (char *[]) {NULL,"",NULL,NULL,NULL,NULL});
+    result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    TEST_CHECK(strstr(result, "test_dummy_labels{B=\"\"} 1 0\n") != NULL);
+    cfl_sds_destroy(result);
+
+
     cmt_counter_set(c, 0, 5, 6, (char *[]) {NULL,NULL,NULL,"d",NULL,NULL});
     result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
     TEST_CHECK(strcmp(result,
@@ -130,6 +136,7 @@ void test_encoding()
         "# TYPE test_dummy_labels counter\n"
         "test_dummy_labels 2 0\n"
         "test_dummy_labels{B=\"b\"} 2 0\n"
+        "test_dummy_labels{B=\"\"} 1 0\n"
         "test_dummy_labels{D=\"d\"} 5 0\n"
         ) == 0);
     cfl_sds_destroy(result);
@@ -141,6 +148,7 @@ void test_encoding()
         "# TYPE test_dummy_labels counter\n"
         "test_dummy_labels 2 0\n"
         "test_dummy_labels{B=\"b\"} 2 0\n"
+        "test_dummy_labels{B=\"\"} 1 0\n"
         "test_dummy_labels{D=\"d\"} 5 0\n"
         "test_dummy_labels{B=\"b\",D=\"d\",F=\"f\"} 50 0\n"
         ) == 0);
@@ -153,6 +161,7 @@ void test_encoding()
         "# TYPE test_dummy_labels counter\n"
         "test_dummy_labels 2 0\n"
         "test_dummy_labels{B=\"b\"} 2 0\n"
+        "test_dummy_labels{B=\"\"} 1 0\n"
         "test_dummy_labels{D=\"d\"} 5 0\n"
         "test_dummy_labels{B=\"b\",D=\"d\",F=\"f\"} 50 0\n"
         "test_dummy_labels{A=\"a\",B=\"b\",C=\"c\",D=\"d\",E=\"e\",F=\"f\"} 1 0\n"

--- a/tests/null_label.c
+++ b/tests/null_label.c
@@ -23,7 +23,10 @@
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_encode_prometheus.h>
+#include <cmetrics/cmt_encode_prometheus_remote_write.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
+
+#include <prometheus_remote_write/remote.pb-c.h>
 
 #include "cmt_tests.h"
 
@@ -91,6 +94,7 @@ void test_encoding()
     struct cmt_counter *c;
     struct cmt_metric *metric;
     struct cmt_map_label *label;
+    uint64_t ts;
 
     cmt = cmt_create();
     c = cmt_counter_create(cmt, "test", "dummy", "labels", "testing labels",
@@ -219,6 +223,114 @@ void test_encoding()
     if (result != NULL) {
         TEST_CHECK(cfl_sds_len(result) == 0);
         cmt_encode_influx_destroy(result);
+    }
+
+    cmt_destroy(cmt);
+
+    cmt = cmt_create();
+    c = cmt_counter_create(cmt, "test", "remote", "labels", "testing remote-write labels",
+                           3, (char *[]) {"A", "B", "C"});
+    ts = cfl_time_now();
+
+    cmt_counter_inc(c, ts, 3, (char *[]) {NULL, NULL, NULL});
+    cmt_counter_inc(c, ts, 3, (char *[]) {NULL, "", NULL});
+    cmt_counter_inc(c, ts, 3, (char *[]) {NULL, "b", NULL});
+    cmt_counter_inc(c, ts, 3, (char *[]) {"a", "b", "c"});
+
+    result = cmt_encode_prometheus_remote_write_create(cmt);
+    TEST_CHECK(result != NULL);
+    if (result != NULL) {
+        Prometheus__WriteRequest *request;
+        size_t series_index;
+        size_t label_index;
+        size_t label_a_count;
+        size_t label_b_count;
+        size_t label_c_count;
+        size_t label_d_count;
+        size_t label_e_count;
+        size_t label_f_count;
+
+        request = prometheus__write_request__unpack(NULL,
+                                                    cfl_sds_len(result),
+                                                    (uint8_t *) result);
+        TEST_CHECK(request != NULL);
+        if (request != NULL) {
+            label_a_count = 0;
+            label_b_count = 0;
+            label_c_count = 0;
+            label_d_count = 0;
+            label_e_count = 0;
+            label_f_count = 0;
+
+            for (series_index = 0; series_index < request->n_timeseries; series_index++) {
+                for (label_index = 0;
+                     label_index < request->timeseries[series_index]->n_labels;
+                     label_index++) {
+                    if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "A") == 0) {
+                        label_a_count++;
+                    }
+                    else if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "B") == 0) {
+                        label_b_count++;
+                    }
+                    else if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "C") == 0) {
+                        label_c_count++;
+                    }
+                    else if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "D") == 0) {
+                        label_d_count++;
+                    }
+                    else if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "E") == 0) {
+                        label_e_count++;
+                    }
+                    else if (strcmp(request->timeseries[series_index]->labels[label_index]->name, "F") == 0) {
+                        label_f_count++;
+                    }
+                }
+            }
+
+            TEST_CHECK(label_a_count == 1);
+            TEST_CHECK(label_b_count == 3);
+            TEST_CHECK(label_c_count == 1);
+            TEST_CHECK(label_d_count == 0);
+            TEST_CHECK(label_e_count == 0);
+            TEST_CHECK(label_f_count == 0);
+            prometheus__write_request__free_unpacked(request, NULL);
+        }
+        cmt_encode_prometheus_remote_write_destroy(result);
+    }
+
+    cmt_destroy(cmt);
+
+    cmt = cmt_create();
+    c = cmt_counter_create(cmt, "test", "remote_nil", "labels",
+                           "testing remote-write nil labels",
+                           1, (char *[]) {"A"});
+
+    cmt_counter_inc(c, ts, 1, (char *[]) {NULL});
+    label = cfl_list_entry_first(&c->map->label_keys, struct cmt_map_label, _head);
+    TEST_CHECK(label != NULL);
+    if (label != NULL) {
+        cfl_sds_destroy(label->name);
+        label->name = NULL;
+    }
+
+    result = cmt_encode_prometheus_remote_write_create(cmt);
+    TEST_CHECK(result != NULL);
+    if (result != NULL) {
+        Prometheus__WriteRequest *request;
+
+        request = prometheus__write_request__unpack(NULL,
+                                                    cfl_sds_len(result),
+                                                    (uint8_t *) result);
+        TEST_CHECK(request != NULL);
+        if (request != NULL) {
+            TEST_CHECK(request->n_timeseries == 1);
+            if (request->n_timeseries == 1) {
+                TEST_CHECK(request->timeseries[0]->n_labels == 1);
+                TEST_CHECK(strcmp(request->timeseries[0]->labels[0]->name, "__name__") == 0);
+            }
+            prometheus__write_request__free_unpacked(request, NULL);
+        }
+        cmt_encode_prometheus_remote_write_destroy(result);
     }
 
     cmt_destroy(cmt);

--- a/tests/opentelemetry.c
+++ b/tests/opentelemetry.c
@@ -579,6 +579,175 @@ static cfl_sds_t generate_gauge_int_otlp_payload_with_attribute(char *attribute_
     return payload;
 }
 
+static cfl_sds_t generate_gauge_int_otlp_payload_with_many_attributes(size_t attribute_count)
+{
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest request;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics resource_metrics;
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics scope_metrics;
+    Opentelemetry__Proto__Metrics__V1__Metric metric;
+    Opentelemetry__Proto__Metrics__V1__Gauge gauge;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint data_point;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics *resource_metrics_list[1];
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics *scope_metrics_list[1];
+    Opentelemetry__Proto__Metrics__V1__Metric *metric_list[1];
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point_list[1];
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute_list;
+    Opentelemetry__Proto__Common__V1__KeyValue **attribute_ptr_list;
+    Opentelemetry__Proto__Common__V1__AnyValue *attribute_value_list;
+    char (*attribute_key_list)[32];
+    char (*attribute_value_text_list)[32];
+    size_t payload_size;
+    size_t index;
+    unsigned char *packed_payload;
+    cfl_sds_t payload;
+
+    attribute_list = calloc(attribute_count, sizeof(Opentelemetry__Proto__Common__V1__KeyValue));
+    attribute_ptr_list = calloc(attribute_count, sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    attribute_value_list = calloc(attribute_count, sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
+    attribute_key_list = calloc(attribute_count, sizeof(*attribute_key_list));
+    attribute_value_text_list = calloc(attribute_count, sizeof(*attribute_value_text_list));
+
+    if (attribute_list == NULL || attribute_ptr_list == NULL ||
+        attribute_value_list == NULL || attribute_key_list == NULL ||
+        attribute_value_text_list == NULL) {
+        free(attribute_list);
+        free(attribute_ptr_list);
+        free(attribute_value_list);
+        free(attribute_key_list);
+        free(attribute_value_text_list);
+
+        return NULL;
+    }
+
+    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__init(&request);
+    opentelemetry__proto__metrics__v1__resource_metrics__init(&resource_metrics);
+    opentelemetry__proto__metrics__v1__scope_metrics__init(&scope_metrics);
+    opentelemetry__proto__metrics__v1__metric__init(&metric);
+    opentelemetry__proto__metrics__v1__gauge__init(&gauge);
+    opentelemetry__proto__metrics__v1__number_data_point__init(&data_point);
+
+    for (index = 0; index < attribute_count; index++) {
+        opentelemetry__proto__common__v1__key_value__init(&attribute_list[index]);
+        opentelemetry__proto__common__v1__any_value__init(&attribute_value_list[index]);
+
+        snprintf(attribute_key_list[index], sizeof(attribute_key_list[index]),
+                 "attr_%03zu", index);
+        snprintf(attribute_value_text_list[index], sizeof(attribute_value_text_list[index]),
+                 "value_%03zu", index);
+
+        attribute_value_list[index].value_case =
+            OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE;
+        attribute_value_list[index].string_value = attribute_value_text_list[index];
+        attribute_list[index].key = attribute_key_list[index];
+        attribute_list[index].value = &attribute_value_list[index];
+        attribute_ptr_list[index] = &attribute_list[index];
+    }
+
+    data_point.time_unix_nano = 123;
+    data_point.value_case =
+        OPENTELEMETRY__PROTO__METRICS__V1__NUMBER_DATA_POINT__VALUE_AS_INT;
+    data_point.as_int = 1;
+    data_point.n_attributes = attribute_count;
+    data_point.attributes = attribute_ptr_list;
+
+    data_point_list[0] = &data_point;
+    gauge.n_data_points = 1;
+    gauge.data_points = data_point_list;
+
+    metric.name = "g_many_attrs";
+    metric.data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE;
+    metric.gauge = &gauge;
+
+    metric_list[0] = &metric;
+    scope_metrics.n_metrics = 1;
+    scope_metrics.metrics = metric_list;
+
+    scope_metrics_list[0] = &scope_metrics;
+    resource_metrics.n_scope_metrics = 1;
+    resource_metrics.scope_metrics = scope_metrics_list;
+
+    resource_metrics_list[0] = &resource_metrics;
+    request.n_resource_metrics = 1;
+    request.resource_metrics = resource_metrics_list;
+
+    payload_size = opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__get_packed_size(&request);
+    packed_payload = calloc(1, payload_size);
+    if (packed_payload == NULL) {
+        payload = NULL;
+    }
+    else {
+        opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__pack(&request,
+                                                                                             packed_payload);
+        payload = cfl_sds_create_len((char *) packed_payload, payload_size);
+        free(packed_payload);
+    }
+
+    free(attribute_list);
+    free(attribute_ptr_list);
+    free(attribute_value_list);
+    free(attribute_key_list);
+    free(attribute_value_text_list);
+
+    return payload;
+}
+
+static cfl_sds_t generate_invalid_otlp_metric_payload(int include_name,
+                                                      int include_data)
+{
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest request;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics resource_metrics;
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics scope_metrics;
+    Opentelemetry__Proto__Metrics__V1__Metric metric;
+    Opentelemetry__Proto__Metrics__V1__Gauge gauge;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics *resource_metrics_list[1];
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics *scope_metrics_list[1];
+    Opentelemetry__Proto__Metrics__V1__Metric *metric_list[1];
+    size_t payload_size;
+    unsigned char *packed_payload;
+    cfl_sds_t payload;
+
+    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__init(&request);
+    opentelemetry__proto__metrics__v1__resource_metrics__init(&resource_metrics);
+    opentelemetry__proto__metrics__v1__scope_metrics__init(&scope_metrics);
+    opentelemetry__proto__metrics__v1__metric__init(&metric);
+    opentelemetry__proto__metrics__v1__gauge__init(&gauge);
+
+    if (include_name) {
+        metric.name = "invalid_metric";
+    }
+
+    if (include_data) {
+        metric.data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE;
+        metric.gauge = &gauge;
+    }
+
+    metric_list[0] = &metric;
+    scope_metrics.n_metrics = 1;
+    scope_metrics.metrics = metric_list;
+
+    scope_metrics_list[0] = &scope_metrics;
+    resource_metrics.n_scope_metrics = 1;
+    resource_metrics.scope_metrics = scope_metrics_list;
+
+    resource_metrics_list[0] = &resource_metrics;
+    request.n_resource_metrics = 1;
+    request.resource_metrics = resource_metrics_list;
+
+    payload_size = opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__get_packed_size(&request);
+    packed_payload = calloc(1, payload_size);
+    if (packed_payload == NULL) {
+        return NULL;
+    }
+
+    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__pack(&request,
+                                                                                         packed_payload);
+
+    payload = cfl_sds_create_len((char *) packed_payload, payload_size);
+    free(packed_payload);
+
+    return payload;
+}
+
 static cfl_sds_t generate_sum_non_monotonic_int_otlp_payload()
 {
     Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest request;
@@ -1423,6 +1592,14 @@ static void test_opentelemetry_missing_attribute_key_rejected(void)
 static void test_opentelemetry_missing_attribute_value_no_crash(void)
 {
     struct cfl_list result_list;
+    struct cmt     *decoded_context;
+    struct cmt_gauge *gauge;
+    struct cmt_metric *metric;
+    struct cmt_map_label *label_value;
+    cfl_sds_t       encoded_payload;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *service_request;
+    Opentelemetry__Proto__Metrics__V1__Metric *roundtrip_metric;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *roundtrip_dp;
     cfl_sds_t       payload;
     size_t          offset;
     int             ret;
@@ -1436,6 +1613,51 @@ static void test_opentelemetry_missing_attribute_value_no_crash(void)
                                               &offset);
         TEST_CHECK(ret == CMT_DECODE_OPENTELEMETRY_SUCCESS);
         if (ret == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
+            decoded_context = cfl_list_entry_first(&result_list, struct cmt, _head);
+            gauge = cfl_list_entry_first(&decoded_context->gauges,
+                                         struct cmt_gauge, _head);
+            TEST_CHECK(gauge != NULL);
+            if (gauge != NULL) {
+                metric = cfl_list_entry_first(&gauge->map->metrics,
+                                              struct cmt_metric, _head);
+                TEST_CHECK(metric != NULL);
+                if (metric != NULL) {
+                    label_value = cfl_list_entry_first(&metric->labels,
+                                                       struct cmt_map_label, _head);
+                    TEST_CHECK(label_value != NULL);
+                    if (label_value != NULL) {
+                        TEST_CHECK(label_value->name == NULL);
+                    }
+                }
+            }
+
+            encoded_payload = cmt_encode_opentelemetry_create(decoded_context);
+            TEST_CHECK(encoded_payload != NULL);
+            if (encoded_payload != NULL) {
+                service_request = opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(
+                    NULL, cfl_sds_len(encoded_payload), (uint8_t *) encoded_payload);
+                TEST_CHECK(service_request != NULL);
+
+                if (service_request != NULL &&
+                    service_request->n_resource_metrics == 1 &&
+                    service_request->resource_metrics[0]->n_scope_metrics == 1 &&
+                    service_request->resource_metrics[0]->scope_metrics[0]->n_metrics == 1) {
+                    roundtrip_metric = service_request->resource_metrics[0]->scope_metrics[0]->metrics[0];
+                    TEST_CHECK(roundtrip_metric->data_case ==
+                               OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE);
+                    if (roundtrip_metric->data_case ==
+                        OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
+                        TEST_CHECK(roundtrip_metric->gauge->n_data_points == 1);
+                        roundtrip_dp = roundtrip_metric->gauge->data_points[0];
+                        TEST_CHECK(roundtrip_dp->n_attributes == 0);
+                    }
+                }
+
+                if (service_request != NULL) {
+                    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(service_request, NULL);
+                }
+                cmt_encode_opentelemetry_destroy(encoded_payload);
+            }
             cmt_decode_opentelemetry_destroy(&result_list);
         }
         cfl_sds_destroy(payload);
@@ -1449,6 +1671,11 @@ static void test_opentelemetry_zero_length_bytes_attribute(void)
     struct cmt_gauge *gauge;
     struct cmt_metric *metric;
     struct cmt_map_label *label_value;
+    cfl_sds_t       encoded_payload;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *service_request;
+    Opentelemetry__Proto__Metrics__V1__Metric *roundtrip_metric;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *roundtrip_dp;
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute;
     cfl_sds_t       payload;
     size_t          offset;
     int             ret;
@@ -1484,10 +1711,184 @@ static void test_opentelemetry_zero_length_bytes_attribute(void)
                     }
                 }
             }
+
+            encoded_payload = cmt_encode_opentelemetry_create(decoded_context);
+            TEST_CHECK(encoded_payload != NULL);
+            if (encoded_payload != NULL) {
+                service_request = opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(
+                    NULL, cfl_sds_len(encoded_payload), (uint8_t *) encoded_payload);
+                TEST_CHECK(service_request != NULL);
+
+                if (service_request != NULL &&
+                    service_request->n_resource_metrics == 1 &&
+                    service_request->resource_metrics[0]->n_scope_metrics == 1 &&
+                    service_request->resource_metrics[0]->scope_metrics[0]->n_metrics == 1) {
+                    roundtrip_metric = service_request->resource_metrics[0]->scope_metrics[0]->metrics[0];
+                    TEST_CHECK(roundtrip_metric->data_case ==
+                               OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE);
+                    if (roundtrip_metric->data_case ==
+                        OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
+                        TEST_CHECK(roundtrip_metric->gauge->n_data_points == 1);
+                        roundtrip_dp = roundtrip_metric->gauge->data_points[0];
+                        TEST_CHECK(roundtrip_dp->n_attributes == 1);
+                        if (roundtrip_dp->n_attributes == 1) {
+                            attribute = roundtrip_dp->attributes[0];
+                            TEST_CHECK(strcmp(attribute->key, "empty_bytes") == 0);
+                            TEST_CHECK(attribute->value->value_case ==
+                                       OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE);
+                            TEST_CHECK(attribute->value->string_value != NULL);
+                            if (attribute->value->string_value != NULL) {
+                                TEST_CHECK(attribute->value->string_value[0] == '\0');
+                            }
+                        }
+                    }
+                }
+
+                if (service_request != NULL) {
+                    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(service_request, NULL);
+                }
+                cmt_encode_opentelemetry_destroy(encoded_payload);
+            }
             cmt_decode_opentelemetry_destroy(&result_list);
         }
         cfl_sds_destroy(payload);
     }
+}
+
+static void test_opentelemetry_many_attributes(void)
+{
+    struct cfl_list result_list;
+    struct cmt     *decoded_context;
+    struct cmt_gauge *gauge;
+    struct cmt_metric *metric;
+    cfl_sds_t       payload;
+    size_t          offset;
+    int             ret;
+
+    payload = generate_gauge_int_otlp_payload_with_many_attributes(130);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        offset = 0;
+        ret = cmt_decode_opentelemetry_create(&result_list,
+                                              payload, cfl_sds_len(payload),
+                                              &offset);
+        TEST_CHECK(ret == CMT_DECODE_OPENTELEMETRY_SUCCESS);
+        if (ret == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
+            decoded_context = cfl_list_entry_first(&result_list, struct cmt, _head);
+            TEST_CHECK(decoded_context != NULL);
+            if (decoded_context != NULL) {
+                gauge = cfl_list_entry_first(&decoded_context->gauges,
+                                             struct cmt_gauge, _head);
+                TEST_CHECK(gauge != NULL);
+                if (gauge != NULL) {
+                    TEST_CHECK(gauge->map->label_count == 130);
+                    metric = cfl_list_entry_first(&gauge->map->metrics,
+                                                  struct cmt_metric, _head);
+                    TEST_CHECK(metric != NULL);
+                    if (metric != NULL) {
+                        TEST_CHECK(cfl_list_size(&metric->labels) == 130);
+                    }
+                }
+            }
+            cmt_decode_opentelemetry_destroy(&result_list);
+        }
+        cfl_sds_destroy(payload);
+    }
+}
+
+static void test_opentelemetry_missing_metric_name_rejected(void)
+{
+    struct cfl_list result_list;
+    cfl_sds_t       payload;
+    size_t          offset;
+    int             ret;
+
+    payload = generate_invalid_otlp_metric_payload(CMT_FALSE, CMT_TRUE);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        offset = 0;
+        ret = cmt_decode_opentelemetry_create(&result_list,
+                                              payload, cfl_sds_len(payload),
+                                              &offset);
+        TEST_CHECK(ret != CMT_DECODE_OPENTELEMETRY_SUCCESS);
+        cfl_sds_destroy(payload);
+    }
+}
+
+static void test_opentelemetry_missing_metric_data_rejected(void)
+{
+    struct cfl_list result_list;
+    cfl_sds_t       payload;
+    size_t          offset;
+    int             ret;
+
+    payload = generate_invalid_otlp_metric_payload(CMT_TRUE, CMT_FALSE);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        offset = 0;
+        ret = cmt_decode_opentelemetry_create(&result_list,
+                                              payload, cfl_sds_len(payload),
+                                              &offset);
+        TEST_CHECK(ret != CMT_DECODE_OPENTELEMETRY_SUCCESS);
+        cfl_sds_destroy(payload);
+    }
+}
+
+static void test_opentelemetry_omitted_null_key_label_encoded(void)
+{
+    int ret;
+    cfl_sds_t payload;
+    struct cmt *cmt;
+    struct cmt_counter *counter;
+    struct cmt_map_label *label_key;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *request;
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+    if (cmt == NULL) {
+        return;
+    }
+
+    counter = cmt_counter_create(cmt, "test", "otlp", "labels",
+                                 "testing otlp labels",
+                                 1, (char *[]) {"A"});
+    TEST_CHECK(counter != NULL);
+    if (counter == NULL) {
+        cmt_destroy(cmt);
+        return;
+    }
+
+    ret = cmt_counter_inc(counter, 0, 1, (char *[]) {NULL});
+    TEST_CHECK(ret == 0);
+
+    label_key = cfl_list_entry_first(&counter->map->label_keys,
+                                     struct cmt_map_label, _head);
+    TEST_CHECK(label_key != NULL);
+    if (label_key != NULL) {
+        cfl_sds_destroy(label_key->name);
+        label_key->name = NULL;
+    }
+
+    payload = cmt_encode_opentelemetry_create(cmt);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        request =
+            opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(NULL,
+                                                                                                  cfl_sds_len(payload),
+                                                                                                  (uint8_t *) payload);
+        TEST_CHECK(request != NULL);
+        if (request != NULL) {
+            TEST_CHECK(request->n_resource_metrics == 1);
+            TEST_CHECK(request->resource_metrics[0]->n_scope_metrics == 1);
+            TEST_CHECK(request->resource_metrics[0]->scope_metrics[0]->n_metrics == 1);
+            TEST_CHECK(request->resource_metrics[0]->scope_metrics[0]->metrics[0]->sum->n_data_points == 1);
+            TEST_CHECK(request->resource_metrics[0]->scope_metrics[0]->metrics[0]->sum->data_points[0]->n_attributes == 0);
+            opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(request, NULL);
+        }
+        cmt_encode_opentelemetry_destroy(payload);
+    }
+
+    cmt_destroy(cmt);
 }
 
 TEST_LIST = {
@@ -1501,5 +1902,9 @@ TEST_LIST = {
     {"opentelemetry_missing_attribute_key_rejected",   test_opentelemetry_missing_attribute_key_rejected},
     {"opentelemetry_missing_attribute_value_no_crash", test_opentelemetry_missing_attribute_value_no_crash},
     {"opentelemetry_zero_length_bytes_attribute",      test_opentelemetry_zero_length_bytes_attribute},
+    {"opentelemetry_many_attributes",                  test_opentelemetry_many_attributes},
+    {"opentelemetry_missing_metric_name_rejected",     test_opentelemetry_missing_metric_name_rejected},
+    {"opentelemetry_missing_metric_data_rejected",     test_opentelemetry_missing_metric_data_rejected},
+    {"opentelemetry_omitted_null_key_label_encoded",   test_opentelemetry_omitted_null_key_label_encoded},
     { 0 }
 };


### PR DESCRIPTION
This hardens omitted/null label handling and malformed payload decoding across cmetrics ingestion/export paths.

**Key changes:**

- Preserve omitted labels distinctly from empty-string labels.
- Harden OTLP, Prometheus remote write, and msgpack decoders against malformed inputs and NULL internal fields.
- Prevent encoders from serializing malformed label sets in ways that merge distinct series.
- Add focused regression coverage for OTLP, remote write, msgpack, Prometheus, and Influx edge cases.