### PR TITLE
prometheus_remote_write: bound native histogram bucket writes to allocated buckets

### DIFF
--- a/src/cmt_decode_prometheus_remote_write.c
+++ b/src/cmt_decode_prometheus_remote_write.c
@@ -575,13 +575,15 @@ static int decode_histogram_points(struct cmt *cmt,
 
     if (result == CMT_DECODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
         if (hist->n_negative_spans > 0) {
-            for (i = 0; i < hist->n_negative_counts; i++) {
+            for (i = 0; i < hist->n_negative_counts &&
+                        (size_t) i < histogram->buckets->count; i++) {
                 cmt_metric_hist_set(metric, hist->timestamp * 1000000,
                                     i, hist->negative_counts[i]);
             }
         }
         else if (hist->n_positive_spans > 0) {
-            for (i = 0; i < hist->n_positive_counts; i++) {
+            for (i = 0; i < hist->n_positive_counts &&
+                        (size_t) i < histogram->buckets->count; i++) {
                 cmt_metric_hist_set(metric, hist->timestamp * 1000000,
                                     i, hist->positive_counts[i]);
             }


### PR DESCRIPTION
For native histograms the bucket array is derived from the histogram spans, while the loops that store bucket values iterate over the length of the counts array (n_negative_counts / n_positive_counts). Those lengths come from the message independently and are not guaranteed to agree.

Bound both loops by histogram->buckets->count so only the span-derived buckets are written and any trailing counts beyond them are ignored, leaving the classic-histogram +Inf slot (index buckets->count) untouched.