### PR TITLE
untyped: remove comparison check with old value

### DIFF
--- a/src/cmt_untyped.c
+++ b/src/cmt_untyped.c
@@ -96,7 +96,7 @@ int cmt_untyped_destroy(struct cmt_untyped *untyped)
     return 0;
 }
 
-/* Set untyped value, new value cannot be smaller than current value */
+/* Set untyped value */
 int cmt_untyped_set(struct cmt_untyped *untyped, uint64_t timestamp, double val,
                     int labels_count, char **label_vals)
 {
@@ -112,9 +112,6 @@ int cmt_untyped_set(struct cmt_untyped *untyped, uint64_t timestamp, double val,
         return -1;
     }
 
-    if (cmt_metric_get_value(metric) > val) {
-        return -1;
-    }
     cmt_metric_set(metric, timestamp, val);
     return 0;
 }

--- a/tests/data/issue_274.txt
+++ b/tests/data/issue_274.txt
@@ -1,0 +1,3 @@
+# HELP node_zfs_arc_memory_available_bytes kstat.zfs.misc.arcstats.memory_available_bytes
+# TYPE node_zfs_arc_memory_available_bytes untyped
+node_zfs_arc_memory_available_bytes -8.58914944e+08

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -1710,6 +1710,20 @@ void test_issue_fluent_bit_9267()
     cfl_sds_destroy(in_buf);
 }
 
+// reproduces https://github.com/fluent/cmetrics/issues/274
+void test_issue_274()
+{
+    int status;
+    struct cmt *cmt;
+    cfl_sds_t in_buf = read_file(CMT_TESTS_DATA_PATH "/issue_274.txt");
+    size_t in_size = cfl_sds_len(in_buf);
+
+    status = cmt_decode_prometheus_create(&cmt, in_buf, in_size, NULL);
+    TEST_CHECK(status == 0);
+    cfl_sds_destroy(in_buf);
+    cmt_decode_prometheus_destroy(cmt);
+}
+
 TEST_LIST = {
     {"header_help", test_header_help},
     {"header_type", test_header_type},
@@ -1744,5 +1758,6 @@ TEST_LIST = {
     {"histogram_different_label_count", test_histogram_different_label_count},
     {"issue_fluent_bit_6534", test_issue_fluent_bit_6534},
     {"issue_fluent_bit_9267", test_issue_fluent_bit_9267},
+    {"issue_274", test_issue_274},
     { 0 }
 };


### PR DESCRIPTION
Untyped metrics do not have any restriction on going back down with respect to their previous value. Only counters do have such restriction. Additionally, this check breaks parsing negative untyped values.

Fixes #274.