### PR TITLE
fix: preserve histogram/exp_histogram temporality across msgpack round-trip

### DIFF
--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -1636,6 +1636,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
     int                                   result;
     struct cmt_summary                   *summary;
     struct cmt_histogram                 *histogram;
+    struct cmt_exp_histogram             *exp_histogram;
     struct cmt_counter                   *counter;
     struct cmt_msgpack_decode_context    *decode_context;
     struct cmt_mpack_map_entry_callback_t callbacks[] = \
@@ -1684,6 +1685,12 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             else {
                 histogram->buckets = NULL;
             }
+
+            histogram->aggregation_type = decode_context->aggregation_type;
+        }
+        else if (decode_context->map->type == CMT_EXP_HISTOGRAM) {
+            exp_histogram = (struct cmt_exp_histogram *) decode_context->map->parent;
+            exp_histogram->aggregation_type = decode_context->aggregation_type;
         }
         else if (decode_context->map->type == CMT_SUMMARY) {
             summary = (struct cmt_summary *) decode_context->map->parent;

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -58,6 +58,7 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     size_t                index;
     struct cmt_summary   *summary = NULL;
     struct cmt_histogram *histogram = NULL;
+    struct cmt_exp_histogram *exp_histogram = NULL;
     struct cmt_counter   *counter = NULL;
     size_t                meta_field_count;
 
@@ -66,6 +67,11 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
 
     if (map->type == CMT_HISTOGRAM) {
         histogram = (struct cmt_histogram *) map->parent;
+
+        meta_field_count += 2;
+    }
+    else if (map->type == CMT_EXP_HISTOGRAM) {
+        exp_histogram = (struct cmt_exp_histogram *) map->parent;
 
         meta_field_count++;
     }
@@ -156,6 +162,15 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
         }
 
         mpack_finish_array(writer);
+
+        /* aggregation_type */
+        mpack_write_cstr(writer, "aggregation_type");
+        mpack_write_int(writer, histogram->aggregation_type);
+    }
+    else if (map->type == CMT_EXP_HISTOGRAM) {
+        /* aggregation_type */
+        mpack_write_cstr(writer, "aggregation_type");
+        mpack_write_int(writer, exp_histogram->aggregation_type);
     }
     else if (map->type == CMT_SUMMARY) {
         /* 'quantiles' (summary quantiles) */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UNIT_TESTS_FILES
   filter.c
   exp_histogram.c
   msgpack_abi.c
+  msgpack_temporality.c
   expire.c
   )
 

--- a/tests/msgpack_temporality.c
+++ b/tests/msgpack_temporality.c
@@ -1,0 +1,213 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2026 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Regression test: histogram and exp_histogram aggregation_type (delta vs
+ * cumulative temporality) must survive a cmt_encode_msgpack /
+ * cmt_decode_msgpack round trip.
+ *
+ * Before this fix, pack_header() in cmt_encode_msgpack.c only wrote the
+ * "aggregation_type" meta field for CMT_COUNTER, so histograms and
+ * exp_histograms always decoded back with CMT_AGGREGATION_TYPE_UNSPECIFIED
+ * regardless of what temporality they were created with. This is the path
+ * Fluent Bit's in_opentelemetry -> (internal msgpack buffer) ->
+ * out_opentelemetry pipeline uses, so any OTLP histogram passing through
+ * Fluent Bit lost its temporality and Prometheus's OTLP receiver rejected it
+ * with "invalid temporality and type combination".
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_exp_histogram.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_encode_msgpack.h>
+#include <cmetrics/cmt_decode_msgpack.h>
+
+#include "cmt_tests.h"
+
+static void test_histogram_temporality_survives_msgpack_roundtrip()
+{
+    int result;
+    char *encoded_buffer;
+    size_t encoded_size;
+    size_t offset;
+    struct cmt *cmt;
+    struct cmt *decoded_cmt;
+    struct cmt_histogram *histogram;
+    struct cmt_histogram *decoded_histogram;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    buckets = cmt_histogram_buckets_default_create();
+    TEST_CHECK(buckets != NULL);
+
+    histogram = cmt_histogram_create(cmt, "k6", "http", "req_duration",
+                                     "request duration", buckets, 0, NULL);
+    TEST_CHECK(histogram != NULL);
+
+    result = cmt_histogram_observe(histogram, 12345, 1.5, 0, NULL);
+    TEST_CHECK(result == 0);
+
+    /* Simulate what an OTLP delta-temporality histogram looks like once
+     * decoded from OTLP into a cmt_histogram (cmt_decode_opentelemetry.c
+     * already sets this correctly; the bug is losing it in the internal
+     * msgpack buffer that sits between Fluent Bit's OTLP input and output
+     * plugins).
+     */
+    histogram->aggregation_type = CMT_AGGREGATION_TYPE_DELTA;
+
+    offset = 0;
+    result = cmt_encode_msgpack_create(cmt, &encoded_buffer, &encoded_size);
+    TEST_CHECK(result == 0);
+
+    result = cmt_decode_msgpack_create(&decoded_cmt, encoded_buffer,
+                                       encoded_size, &offset);
+    TEST_CHECK(result == CMT_DECODE_MSGPACK_SUCCESS);
+
+    if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        TEST_CHECK(cfl_list_size(&decoded_cmt->histograms) == 1);
+
+        decoded_histogram = cfl_list_entry_first(&decoded_cmt->histograms,
+                                                 struct cmt_histogram, _head);
+        TEST_CHECK(decoded_histogram != NULL);
+
+        if (decoded_histogram != NULL) {
+            TEST_CHECK(decoded_histogram->aggregation_type ==
+                      CMT_AGGREGATION_TYPE_DELTA);
+        }
+
+        cmt_decode_msgpack_destroy(decoded_cmt);
+    }
+
+    cmt_encode_msgpack_destroy(encoded_buffer);
+    cmt_destroy(cmt);
+}
+
+static void test_exp_histogram_temporality_survives_msgpack_roundtrip()
+{
+    int result;
+    char *encoded_buffer;
+    size_t encoded_size;
+    size_t offset;
+    struct cmt *cmt;
+    struct cmt *decoded_cmt;
+    struct cmt_exp_histogram *exp_histogram;
+    struct cmt_exp_histogram *decoded_exp_histogram;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    exp_histogram = cmt_exp_histogram_create(cmt, "k6", "http", "req_duration",
+                                             "request duration", 0, NULL);
+    TEST_CHECK(exp_histogram != NULL);
+
+    exp_histogram->aggregation_type = CMT_AGGREGATION_TYPE_DELTA;
+
+    offset = 0;
+    result = cmt_encode_msgpack_create(cmt, &encoded_buffer, &encoded_size);
+    TEST_CHECK(result == 0);
+
+    result = cmt_decode_msgpack_create(&decoded_cmt, encoded_buffer,
+                                       encoded_size, &offset);
+    TEST_CHECK(result == CMT_DECODE_MSGPACK_SUCCESS);
+
+    if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        TEST_CHECK(cfl_list_size(&decoded_cmt->exp_histograms) == 1);
+
+        decoded_exp_histogram = cfl_list_entry_first(&decoded_cmt->exp_histograms,
+                                                      struct cmt_exp_histogram,
+                                                      _head);
+        TEST_CHECK(decoded_exp_histogram != NULL);
+
+        if (decoded_exp_histogram != NULL) {
+            TEST_CHECK(decoded_exp_histogram->aggregation_type ==
+                      CMT_AGGREGATION_TYPE_DELTA);
+        }
+
+        cmt_decode_msgpack_destroy(decoded_cmt);
+    }
+
+    cmt_encode_msgpack_destroy(encoded_buffer);
+    cmt_destroy(cmt);
+}
+
+static void test_counter_temporality_still_survives_msgpack_roundtrip()
+{
+    int result;
+    char *encoded_buffer;
+    size_t encoded_size;
+    size_t offset;
+    struct cmt *cmt;
+    struct cmt *decoded_cmt;
+    struct cmt_counter *counter;
+    struct cmt_counter *decoded_counter;
+
+    cmt_initialize();
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    counter = cmt_counter_create(cmt, "k6", "http", "reqs", "requests", 0, NULL);
+    TEST_CHECK(counter != NULL);
+
+    counter->aggregation_type = CMT_AGGREGATION_TYPE_DELTA;
+
+    offset = 0;
+    result = cmt_encode_msgpack_create(cmt, &encoded_buffer, &encoded_size);
+    TEST_CHECK(result == 0);
+
+    result = cmt_decode_msgpack_create(&decoded_cmt, encoded_buffer,
+                                       encoded_size, &offset);
+    TEST_CHECK(result == CMT_DECODE_MSGPACK_SUCCESS);
+
+    if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        TEST_CHECK(cfl_list_size(&decoded_cmt->counters) == 1);
+
+        decoded_counter = cfl_list_entry_first(&decoded_cmt->counters,
+                                               struct cmt_counter, _head);
+        TEST_CHECK(decoded_counter != NULL);
+
+        if (decoded_counter != NULL) {
+            TEST_CHECK(decoded_counter->aggregation_type ==
+                      CMT_AGGREGATION_TYPE_DELTA);
+        }
+
+        cmt_decode_msgpack_destroy(decoded_cmt);
+    }
+
+    cmt_encode_msgpack_destroy(encoded_buffer);
+    cmt_destroy(cmt);
+}
+
+TEST_LIST = {
+    {"histogram_temporality_survives_msgpack_roundtrip",
+     test_histogram_temporality_survives_msgpack_roundtrip},
+    {"exp_histogram_temporality_survives_msgpack_roundtrip",
+     test_exp_histogram_temporality_survives_msgpack_roundtrip},
+    {"counter_temporality_still_survives_msgpack_roundtrip",
+     test_counter_temporality_still_survives_msgpack_roundtrip},
+    {NULL, NULL}
+};


### PR DESCRIPTION
Resolves #278

## Summary

`pack_header()` in `cmt_encode_msgpack.c` only writes the `aggregation_type` meta field for `CMT_COUNTER`. Histograms and exp_histograms encoded to msgpack and decoded back always end up with `CMT_AGGREGATION_TYPE_UNSPECIFIED`, regardless of the temporality (delta/cumulative) they were created with — because `unpack_basic_type_meta()` in `cmt_decode_msgpack.c` never applies the decoded `aggregation_type` back onto those two types either.

This fix mirrors the existing `CMT_COUNTER` handling for `CMT_HISTOGRAM` and `CMT_EXP_HISTOGRAM`, on both the encode and decode side.

## Real-world impact

This is the exact code path Fluent Bit's OTLP pipeline uses internally:

```
OTLP client → in_opentelemetry (decodes OTLP → cmetrics)
            → [internal msgpack buffer]
            → out_opentelemetry (decodes msgpack → re-encodes OTLP)
            → OTLP receiver (e.g. Prometheus)
```

Any OTLP histogram with delta or cumulative temporality passing through Fluent Bit loses that metadata in the msgpack round-trip. Downstream OTLP receivers that validate temporality (e.g. Prometheus with `otlp-deltatocumulative` enabled) reject the metric:

```
invalid temporality and type combination for metric "k6_http_req_duration"
```
## Root cause, traced with evidence

- `cmt_decode_opentelemetry.c` / `cmt_encode_opentelemetry.c` (the direct OTLP codec) correctly round-trip `aggregation_type` for histograms — confirmed by reading the source.
- `cmt_encode_msgpack.c` / `cmt_decode_msgpack.c` (the internal msgpack codec Fluent Bit uses for its input/output plugin boundary) do **not** — confirmed by reading the source and reproducing locally.
- Reproduced against a live cluster: built a patched Fluent Bit v5.0.4 with this fix applied to the vendored `lib/cmetrics` copy, deployed it in place of the stock image, ran a k6 OTLP load test through the same Fluent Bit pipeline, and confirmed via direct Prometheus API query that `k6_http_req_duration_milliseconds_bucket`/`_count`/`_sum` (previously rejected) now land correctly with real data.

## Test plan

Added `tests/msgpack_temporality.c`: round-trips a histogram, an exp_histogram, and a counter (as a control) through `cmt_encode_msgpack_create` → `cmt_decode_msgpack_create` and asserts `aggregation_type` survives.

- [x] `ctest` passes: 18/18 (17 pre-existing + this new test), no regressions
- [x] Verified the new test **fails** on histogram and exp_histogram (counter still passes, as expected) when reverting `src/cmt_encode_msgpack.c` / `src/cmt_decode_msgpack.c` only — confirms the test actually exercises the bug
- [x] Verified the fix against a real Fluent Bit deployment with real OTLP traffic (see above), not just unit tests