### PR TITLE
build: define YY_NO_UNISTD_H only for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,12 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(CMT_SYSTEM_WINDOWS On)
   add_definitions(-DCMT_SYSTEM_WINDOWS)
 
-  # Disable unistd.h for flex/bison
-  CMT_DEFINITION(YY_NO_UNISTD_H)
-  message(STATUS "Specifying YY_NO_UNISTD_H")
+  # Disable unistd.h for flex/bison on MSVC only: MinGW provides a real
+  # unistd.h, and without it the generated lexer has no isatty declaration.
+  if(MSVC)
+    CMT_DEFINITION(YY_NO_UNISTD_H)
+    message(STATUS "Specifying YY_NO_UNISTD_H")
+  endif()
 endif()
 
 # Define macro to identify macOS system


### PR DESCRIPTION
`YY_NO_UNISTD_H` is currently defined for all Windows targets to keep the flex-generated lexer from including `<unistd.h>`. That's correct for MSVC, which has no `unistd.h`, but wrong for MinGW-w64: MinGW ships a real `unistd.h`, and suppressing it leaves the generated lexer without a declaration of `isatty()`, which GCC 14 and later reject as an implicit function declaration (an error by default).

Gate the definition on `MSVC` so MinGW builds get the real `unistd.h`. No change for MSVC.

### Testing

Verified by cross-compiling Fluent Bit (which bundles cmetrics) for Windows from Linux with the Fedora MinGW-w64 UCRT toolchain: the cmetrics prometheus decode lexer compiles instead of failing on the implicit `isatty` declaration. MSVC builds are unaffected — the definition still applies there.