### PR TITLE
encode: avoid .0 suffix on non-finite bucket labels

### DIFF
--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdbool.h>
+#include <math.h>
 #include <stdlib.h>
 
 #include <cmetrics/cmetrics.h>
@@ -407,7 +408,12 @@ static cfl_sds_t bucket_value_to_string(double val)
     }
     cfl_sds_len_set(str, len);
 
-    if (!strchr(str, '.') && !strchr(str, 'e') && !strchr(str, 'E')) {
+    /*
+     * Append .0 only when there is no decimal point and the number
+     * is finite and not in scientific notation.
+     */
+    if (isfinite(val) &&
+        !strchr(str, '.') && !strchr(str, 'e') && !strchr(str, 'E')) {
         cfl_sds_cat_safe(&str, ".0", 2);
     }
 

--- a/tests/histogram.c
+++ b/tests/histogram.c
@@ -109,6 +109,51 @@ static void prometheus_encode_test(struct cmt *cmt)
     cmt_encode_prometheus_destroy(buf);
 }
 
+void test_histogram_non_finite_bucket_labels()
+{
+    /* Cover non-finite %g outputs like inf/nan. */
+    uint64_t ts;
+    cfl_sds_t buf;
+    struct cmt *cmt;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt_initialize();
+
+    ts = 0;
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    buckets = cmt_histogram_buckets_create(3, -INFINITY, NAN, INFINITY);
+    TEST_CHECK(buckets != NULL);
+
+    h = cmt_histogram_create(cmt,
+                             "cm", "encoding", "non_finite_bucket",
+                             "Histogram non-finite bucket label",
+                             buckets,
+                             0, NULL);
+    TEST_CHECK(h != NULL);
+
+    cmt_histogram_observe(h, ts, 42.0, 0, NULL);
+
+    buf = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    TEST_CHECK(buf != NULL);
+    if (buf != NULL) {
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_non_finite_bucket_bucket{le=\"-inf\"} 0 0") != NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_non_finite_bucket_bucket{le=\"nan\"} 1 0") != NULL);
+        TEST_CHECK(strstr(buf,
+                          "cm_encoding_non_finite_bucket_bucket{le=\"inf\"} 1 0") != NULL);
+        TEST_CHECK(strstr(buf, "le=\"-inf.0\"") == NULL);
+        TEST_CHECK(strstr(buf, "le=\"nan.0\"") == NULL);
+        TEST_CHECK(strstr(buf, "le=\"inf.0\"") == NULL);
+        cmt_encode_prometheus_destroy(buf);
+    }
+
+    cmt_destroy(cmt);
+}
+
 
 void test_histogram()
 {
@@ -257,6 +302,7 @@ void test_prometheus_large_integer_bucket_precision()
 }
 
 TEST_LIST = {
+    {"non_finite_bucket_labels"                 , test_histogram_non_finite_bucket_labels},
     {"histogram"                                , test_histogram},
     {"set_defaults"                             , test_set_defaults},
     {"prometheus_large_integer_bucket_precision", test_prometheus_large_integer_bucket_precision},


### PR DESCRIPTION
Supersedes the remaining relevant part of #261 after rebasing its intent onto current `master`.

Current `master` already contains the newer histogram bucket precision and exponent-formatting fixes, so this keeps only the non-finite handling that is still needed: `inf` and `nan` bucket labels must not be emitted as malformed `inf.0` and `nan.0` values.

The original commit was cherry-picked and resolved against current `master`, preserving Luis Pigueiras as the commit author and retaining the focused regression coverage derived from his contribution.

Validation:
- `cmt-test-histogram`
- `cmt-test-encoding`
- full test suite: 20/20 passed