### PR TITLE
map: fix metric lookup and summary correctness

### DIFF
--- a/include/cmetrics/cmt_map.h
+++ b/include/cmetrics/cmt_map.h
@@ -43,12 +43,18 @@ struct cmt_map {
     int label_count;            /* Number of labels */
     struct cfl_list label_keys;  /* Linked list of labels */
     void *parent;
+
+    /* Internal lock. Keep this after the established public fields. */
+    uint64_t metric_lock;
 };
 
 struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts,
                                int count, char **labels, void *parent);
 void cmt_map_destroy(struct cmt_map *map);
 
+/* Concurrent lookups and metric creation are serialized internally. The
+ * returned metric remains caller-usable only while the map is not expired or
+ * destroyed. */
 struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map,
                                       int labels_count, char **labels_val,
                                       int write_op);
@@ -57,6 +63,7 @@ int cmt_map_metric_get_val(struct cmt_opts *opts, struct cmt_map *map,
                            double *out_val);
 void cmt_map_metric_destroy(struct cmt_metric *metric);
 
+/* Expiration requires external coordination with metric users. */
 void cmt_map_metrics_expire(struct cmt_map *, uint64_t);
 
 void destroy_label_list(struct cfl_list *label_list);

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -1336,6 +1336,8 @@ static int unpack_metric_array_entry(mpack_reader_t *reader, size_t index, void 
             else if (decode_context->map->type == CMT_SUMMARY) {
                 cmt_atomic_store(&decode_context->map->metric.sum_quantiles_set, cmt_atomic_load(&metric->sum_quantiles_set));
                 decode_context->map->metric.sum_quantiles = metric->sum_quantiles;
+                decode_context->map->metric.sum_quantiles_count =
+                    metric->sum_quantiles_count;
                 cmt_atomic_store(&decode_context->map->metric.sum_count,
                                  cmt_atomic_load(&metric->sum_count));
                 cmt_atomic_store(&decode_context->map->metric.sum_sum,

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -21,7 +21,21 @@
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_log.h>
 #include <cmetrics/cmt_metric.h>
+#include <cmetrics/cmt_atomic.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_summary.h>
 #include <cmetrics/cmt_compat.h>
+
+static void map_lock(struct cmt_map *map)
+{
+    while (cmt_atomic_compare_exchange(&map->metric_lock, 0, 1) == 0) {
+    }
+}
+
+static void map_unlock(struct cmt_map *map)
+{
+    cmt_atomic_store(&map->metric_lock, 0);
+}
 
 struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts, int count, char **labels,
                                void *parent)
@@ -76,7 +90,75 @@ struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts, int count, char 
     return NULL;
 }
 
-static struct cmt_metric *metric_hash_lookup(struct cmt_map *map, uint64_t hash)
+static int metric_labels_match(struct cmt_metric *metric,
+                               int labels_count, char **labels_val)
+{
+    int index = 0;
+    struct cfl_list *head;
+    struct cmt_map_label *label;
+
+    cfl_list_foreach(head, &metric->labels) {
+        if (index >= labels_count) {
+            return CMT_FALSE;
+        }
+
+        label = cfl_list_entry(head, struct cmt_map_label, _head);
+        if ((label->name == NULL) != (labels_val[index] == NULL)) {
+            return CMT_FALSE;
+        }
+        if (label->name != NULL && strcmp(label->name, labels_val[index]) != 0) {
+            return CMT_FALSE;
+        }
+        index++;
+    }
+
+    return index == labels_count;
+}
+
+static struct cmt_metric *metric_prepare_storage(struct cmt_map *map,
+                                                 struct cmt_metric *metric,
+                                                 int write_op)
+{
+    struct cmt_summary *summary;
+    struct cmt_histogram *histogram;
+
+    if (metric == NULL || !write_op) {
+        return metric;
+    }
+
+    if (map->type == CMT_HISTOGRAM && metric->hist_buckets == NULL) {
+        histogram = map->parent;
+        if (histogram == NULL || histogram->buckets == NULL) {
+            return NULL;
+        }
+        metric->hist_buckets = calloc(histogram->buckets->count + 1,
+                                      sizeof(uint64_t));
+        if (metric->hist_buckets == NULL) {
+            cmt_errno();
+            return NULL;
+        }
+    }
+    else if (map->type == CMT_SUMMARY && metric->sum_quantiles == NULL) {
+        summary = map->parent;
+        if (summary == NULL) {
+            return NULL;
+        }
+        if (summary->quantiles_count > 0) {
+            metric->sum_quantiles = calloc(summary->quantiles_count,
+                                           sizeof(uint64_t));
+            if (metric->sum_quantiles == NULL) {
+                cmt_errno();
+                return NULL;
+            }
+        }
+        metric->sum_quantiles_count = summary->quantiles_count;
+    }
+
+    return metric;
+}
+
+static struct cmt_metric *metric_hash_lookup(struct cmt_map *map, uint64_t hash,
+                                             int labels_count, char **labels_val)
 {
     struct cfl_list *head;
     struct cmt_metric *metric;
@@ -87,7 +169,8 @@ static struct cmt_metric *metric_hash_lookup(struct cmt_map *map, uint64_t hash)
 
     cfl_list_foreach(head, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
-        if (metric->hash == hash) {
+        if (metric->hash == hash &&
+            metric_labels_match(metric, labels_count, labels_val)) {
             return metric;
         }
     }
@@ -137,6 +220,7 @@ static struct cmt_metric *map_metric_create(uint64_t hash,
     return metric;
 
  error:
+    destroy_label_list(&metric->labels);
     free(metric);
     return NULL;
 }
@@ -171,12 +255,14 @@ void cmt_map_metric_destroy(struct cmt_metric *metric)
     free(metric);
 }
 
-struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map,
-                                      int labels_count, char **labels_val,
-                                      int write_op)
+static struct cmt_metric *map_metric_get_unlocked(struct cmt_opts *opts,
+                                                  struct cmt_map *map,
+                                                  int labels_count,
+                                                  char **labels_val,
+                                                  int write_op)
 {
     int i;
-    int len;
+    size_t len;
     char *ptr;
     uint64_t hash;
     cfl_hash_state_t state;
@@ -207,7 +293,7 @@ struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map
         }
 
         /* return the proper context or NULL */
-        return metric;
+        return metric_prepare_storage(map, metric, write_op);
     }
 
     /* Lookup the metric */
@@ -225,10 +311,10 @@ struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map
     }
 
     hash = cfl_hash_64bits_digest(&state);
-    metric = metric_hash_lookup(map, hash);
+    metric = metric_hash_lookup(map, hash, labels_count, labels_val);
 
     if (metric) {
-        return metric;
+        return metric_prepare_storage(map, metric, write_op);
     }
 
     /*
@@ -245,6 +331,20 @@ struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map
         return NULL;
     }
     cfl_list_add(&metric->_head, &map->metrics);
+    return metric_prepare_storage(map, metric, write_op);
+}
+
+struct cmt_metric *cmt_map_metric_get(struct cmt_opts *opts, struct cmt_map *map,
+                                      int labels_count, char **labels_val,
+                                      int write_op)
+{
+    struct cmt_metric *metric;
+
+    map_lock(map);
+    metric = map_metric_get_unlocked(opts, map, labels_count, labels_val,
+                                     write_op);
+    map_unlock(map);
+
     return metric;
 }
 
@@ -347,10 +447,12 @@ void cmt_map_metrics_expire(struct cmt_map *map, uint64_t expiration)
     struct cfl_list *head;
     struct cmt_metric *metric;
 
+    map_lock(map);
     cfl_list_foreach_safe(head, tmp, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
         if (metric->timestamp < expiration) {
             cmt_map_metric_destroy(metric);
         }
     }
+    map_unlock(map);
 }

--- a/src/cmt_summary.c
+++ b/src/cmt_summary.c
@@ -94,7 +94,7 @@ struct cmt_summary *cmt_summary_create(struct cmt *cmt,
     if (quantiles_count > 0) {
         s->quantiles_count = quantiles_count;
         s->quantiles = calloc(1, sizeof(double) * quantiles_count);
-        if (!s->quantiles_count) {
+        if (!s->quantiles) {
             cmt_errno();
             cmt_summary_destroy(s);
             return NULL;
@@ -130,7 +130,8 @@ double cmt_summary_quantile_get_value(struct cmt_metric *metric, int quantile_id
 {
     uint64_t val;
 
-    if (quantile_id < 0 /*|| quantile_id > metric->sum_quantiles_count*/) {
+    if (metric == NULL || metric->sum_quantiles == NULL || quantile_id < 0 ||
+        (size_t) quantile_id >= metric->sum_quantiles_count) {
         return 0;
     }
 
@@ -219,6 +220,11 @@ void cmt_summary_quantile_set(struct cmt_metric *metric, uint64_t timestamp,
     double   old;
     double   new;
     int      result;
+
+    if (metric == NULL || metric->sum_quantiles == NULL || quantile_id < 0 ||
+        (size_t) quantile_id >= metric->sum_quantiles_count) {
+        return;
+    }
 
     do {
         old = cmt_summary_quantile_get_value(metric, quantile_id);

--- a/tests/counter.c
+++ b/tests/counter.c
@@ -21,8 +21,13 @@
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
+#include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_encode_text.h>
+
+#if !defined(_WIN32) && !defined(_WIN64)
+#include <pthread.h>
+#endif
 
 #include "cmt_tests.h"
 
@@ -243,6 +248,20 @@ void test_labels()
     TEST_CHECK(ret == 0);
     TEST_CHECK(val == 10.55);
 
+    /* Label boundaries must be part of identity. These two tuples feed the
+     * same unframed byte sequence ("abc") into the hash. */
+    ret = cmt_counter_add(c, ts, 4.0, 2, (char *[]) {"ab", "c"});
+    TEST_CHECK(ret == 0);
+    ret = cmt_counter_add(c, ts, 7.0, 2, (char *[]) {"a", "bc"});
+    TEST_CHECK(ret == 0);
+
+    ret = cmt_counter_get_val(c, 2, (char *[]) {"ab", "c"}, &val);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(val == 4.0);
+    ret = cmt_counter_get_val(c, 2, (char *[]) {"a", "bc"}, &val);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(val == 7.0);
+
     /* Valid counter set */
     ret = cmt_counter_set(c, ts, 12.15, 2, (char *[]) {"localhost", "test"});
     TEST_CHECK(ret == 0);
@@ -254,11 +273,76 @@ void test_labels()
     cmt_destroy(cmt);
 }
 
+#if !defined(_WIN32) && !defined(_WIN64)
+#define CONCURRENT_THREAD_COUNT 8
+#define CONCURRENT_UPDATE_COUNT 10000
+
+struct concurrent_counter_context {
+    struct cmt_counter *counter;
+    int result;
+};
+
+static void *concurrent_counter_worker(void *data)
+{
+    int index;
+    struct concurrent_counter_context *context = data;
+
+    for (index = 0; index < CONCURRENT_UPDATE_COUNT; index++) {
+        if (cmt_counter_inc(context->counter, (uint64_t) index + 1, 1,
+                            (char *[]) {"shared"}) != 0) {
+            context->result = -1;
+            break;
+        }
+    }
+
+    return NULL;
+}
+
+void test_concurrent_metric_creation()
+{
+    int index;
+    int result;
+    double value;
+    pthread_t threads[CONCURRENT_THREAD_COUNT];
+    struct concurrent_counter_context contexts[CONCURRENT_THREAD_COUNT];
+    struct cmt *cmt;
+    struct cmt_counter *counter;
+
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+    counter = cmt_counter_create(cmt, "test", "", "concurrent", "help",
+                                 1, (char *[]) {"series"});
+    TEST_ASSERT(counter != NULL);
+
+    for (index = 0; index < CONCURRENT_THREAD_COUNT; index++) {
+        contexts[index].counter = counter;
+        contexts[index].result = 0;
+        result = pthread_create(&threads[index], NULL,
+                                concurrent_counter_worker, &contexts[index]);
+        TEST_ASSERT(result == 0);
+    }
+    for (index = 0; index < CONCURRENT_THREAD_COUNT; index++) {
+        pthread_join(threads[index], NULL);
+        TEST_CHECK(contexts[index].result == 0);
+    }
+
+    TEST_CHECK(cfl_list_size(&counter->map->metrics) == 1);
+    result = cmt_counter_get_val(counter, 1, (char *[]) {"shared"}, &value);
+    TEST_CHECK(result == 0);
+    TEST_CHECK(value == CONCURRENT_THREAD_COUNT * CONCURRENT_UPDATE_COUNT);
+
+    cmt_destroy(cmt);
+}
+#endif
+
 TEST_LIST = {
     {"basic", test_counter},
     {"labels", test_labels},
     {"msgpack", test_msgpack},
     {"prometheus", test_prometheus},
     {"text", test_text},
+#if !defined(_WIN32) && !defined(_WIN64)
+    {"concurrent_metric_creation", test_concurrent_metric_creation},
+#endif
     { 0 }
 };

--- a/tests/summary.c
+++ b/tests/summary.c
@@ -19,6 +19,7 @@
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_encode_text.h>
 
@@ -90,6 +91,36 @@ void test_set_defaults()
     /* static label: register static label for the context */
     cmt_label_add(cmt, "static", "test");
     prometheus_encode_test(cmt);
+
+    cmt_destroy(cmt);
+}
+
+void test_quantile_bounds()
+{
+    uint64_t ts;
+    double quantiles[] = {0.5};
+    double values[] = {12.0};
+    struct cmt *cmt;
+    struct cmt_metric *metric;
+    struct cmt_summary *summary;
+
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+    summary = cmt_summary_create(cmt, "test", "", "summary", "help",
+                                 1, quantiles, 0, NULL);
+    TEST_ASSERT(summary != NULL);
+    ts = cfl_time_now();
+    TEST_ASSERT(cmt_summary_set_default(summary, ts, values, 12.0, 1,
+                                        0, NULL) == 0);
+    metric = cmt_map_metric_get(&summary->opts, summary->map, 0, NULL,
+                                CMT_FALSE);
+    TEST_ASSERT(metric != NULL);
+
+    TEST_CHECK(cmt_summary_quantile_get_value(metric, 0) == 12.0);
+    TEST_CHECK(cmt_summary_quantile_get_value(metric, -1) == 0.0);
+    TEST_CHECK(cmt_summary_quantile_get_value(metric, 1) == 0.0);
+    cmt_summary_quantile_set(metric, ts, 1, 99.0);
+    TEST_CHECK(cmt_summary_quantile_get_value(metric, 0) == 12.0);
 
     cmt_destroy(cmt);
 }
@@ -167,6 +198,7 @@ void fluentbit_bug_5894()
 
 TEST_LIST = {
     {"set_defaults"      , test_set_defaults},
+    {"quantile_bounds"   , test_quantile_bounds},
     {"fluentbit_bug_5894", fluentbit_bug_5894},
     { 0 }
 };


### PR DESCRIPTION
## Summary

- make labeled metric identity collision-safe by verifying exact label values
- serialize lookup and first-time metric creation, including histogram and summary storage initialization
- clean up partially constructed label lists on allocation failure
- validate summary quantile allocation and bounds
- preserve the static-summary quantile count across MessagePack decoding

## Root cause

Metric identity relied only on an unframed 64-bit hash, concurrent first writers could mutate map structures and lazy storage without synchronization, and static summary decoding transferred the quantile buffer without its count. The missing count became visible once quantile access correctly enforced bounds.

## Impact

Distinct colliding label tuples remain separate, concurrent creation of the same series no longer creates duplicates, first writes do not race storage allocation, and static summaries retain quantiles after a MessagePack round trip.

Expiration and destruction still require external lifetime coordination because the API returns raw metric pointers.

## Validation

- Full unit suite: 20/20 passed
- Valgrind Memcheck over all 20 test executables: no invalid accesses or definite/indirect leaks
- Eight-thread concurrent creation regression: 80,000 updates and one resulting series