### PR TITLE
map: index metrics for high-cardinality lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+## Testing
+
+- When making code changes, run the related unit test when one is available.
+
+## Performance
+
+- Build benchmarks with `CMT_BENCHMARKS=ON` and an optimized Release build.
+- For performance changes, capture at least five before and five after runs on
+  the same machine with identical compiler flags and workload parameters.
+- Use `benchmarks/run-perf.sh` for the standard workloads and Linux `perf stat`
+  hardware counters. Keep only changes with repeatable improvements and no
+  relevant benchmark regressions.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 option(CMT_DEV                       "Enable development mode"                    No)
 option(CMT_DEBUG                     "Enable debug mode"                          No)
 option(CMT_TESTS                     "Enable unit testing"                        No)
+option(CMT_BENCHMARKS                "Build performance benchmarks"               No)
 option(CMT_INSTALL_TARGETS           "Enable subdirectory library installations" Yes)
 option(CMT_PROMETHEUS_TEXT_DECODER   "Enable prometheus text format decoder (requires Flex/Bison)" Yes)
 
@@ -301,6 +302,10 @@ endif()
 # Source code
 add_subdirectory(include)
 add_subdirectory(src)
+
+if(CMT_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
 
 # Tests
 if(CMT_TESTS)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(cmt-benchmark benchmark.c)
+target_link_libraries(cmt-benchmark cmetrics-static cfl-static fluent-otel-proto)
+
+if(NOT CMT_SYSTEM_WINDOWS)
+  target_link_libraries(cmt-benchmark pthread)
+endif()

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,33 @@
+# CMetrics benchmarks
+
+Benchmarks are opt-in and are intended for before/after comparisons on the
+same machine. Build an optimized binary:
+
+```sh
+cmake -S . -B build-perf \
+    -DCMT_BENCHMARKS=ON \
+    -DCMT_INSTALL_TARGETS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG'
+cmake --build build-perf -j --target cmt-benchmark
+```
+
+Run the standard repeated workloads and Linux hardware counters:
+
+```sh
+REPETITIONS=5 benchmarks/run-perf.sh \
+    ./build-perf/benchmarks/cmt-benchmark
+```
+
+The executable also accepts individual workloads:
+
+```text
+cmt-benchmark lookup|update|prometheus CARDINALITY OPERATIONS
+```
+
+Compare medians from at least five alternating before/after runs. Keep CPU
+frequency policy, compiler, flags, machine load, and input parameters fixed.
+Use the reported in-process `elapsed_ns` for the operation itself and `perf
+stat` for whole-process hardware counters. Whole-process counters include
+series construction and teardown by design, exposing setup complexity as well
+as steady-state behavior.

--- a/benchmarks/benchmark.c
+++ b/benchmarks/benchmark.c
@@ -1,0 +1,202 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_encode_prometheus.h>
+
+static uint64_t monotonic_ns(void)
+{
+    struct timespec timestamp;
+
+    clock_gettime(CLOCK_MONOTONIC, &timestamp);
+
+    return (uint64_t) timestamp.tv_sec * 1000000000ULL + timestamp.tv_nsec;
+}
+
+static size_t parse_size(const char *text, const char *name)
+{
+    char *end;
+    unsigned long long value;
+
+    errno = 0;
+    value = strtoull(text, &end, 10);
+    if (errno != 0 || *text == '\0' || *end != '\0' || value == 0) {
+        fprintf(stderr, "invalid %s: %s\n", name, text);
+        exit(EXIT_FAILURE);
+    }
+
+    return (size_t) value;
+}
+
+static struct cmt_counter *create_series(struct cmt *cmt, size_t cardinality)
+{
+    size_t index;
+    int result;
+    char label[32];
+    char *values[] = {label};
+    struct cmt_counter *counter;
+
+    counter = cmt_counter_create(cmt, "bench", "", "counter", "benchmark",
+                                 1, (char *[]) {"series"});
+    if (counter == NULL) {
+        return NULL;
+    }
+
+    for (index = 0; index < cardinality; index++) {
+        snprintf(label, sizeof(label), "series-%zu", index);
+        result = cmt_counter_set(counter, 1, 1.0, 1, values);
+        if (result != 0) {
+            return NULL;
+        }
+    }
+
+    return counter;
+}
+
+static int benchmark_lookup(size_t cardinality, size_t operations)
+{
+    size_t index;
+    int result;
+    double value;
+    uint64_t start;
+    uint64_t elapsed;
+    char label[32];
+    char *values[] = {label};
+    struct cmt *cmt;
+    struct cmt_counter *counter;
+
+    cmt = cmt_create();
+    counter = create_series(cmt, cardinality);
+    if (counter == NULL) {
+        cmt_destroy(cmt);
+        return -1;
+    }
+
+    start = monotonic_ns();
+    for (index = 0; index < operations; index++) {
+        snprintf(label, sizeof(label), "series-%zu", index % cardinality);
+        result = cmt_counter_get_val(counter, 1, values, &value);
+        if (result != 0 || value != 1.0) {
+            cmt_destroy(cmt);
+            return -1;
+        }
+    }
+    elapsed = monotonic_ns() - start;
+
+    printf("benchmark=lookup cardinality=%zu operations=%zu elapsed_ns=%" PRIu64
+           " ns_per_op=%.2f ops_per_second=%.2f\n",
+           cardinality, operations, elapsed, (double) elapsed / operations,
+           (double) operations * 1000000000.0 / elapsed);
+    cmt_destroy(cmt);
+    return 0;
+}
+
+static int benchmark_update(size_t cardinality, size_t operations)
+{
+    size_t index;
+    int result;
+    uint64_t start;
+    uint64_t elapsed;
+    char label[32];
+    char *values[] = {label};
+    struct cmt *cmt;
+    struct cmt_counter *counter;
+
+    cmt = cmt_create();
+    counter = create_series(cmt, cardinality);
+    if (counter == NULL) {
+        cmt_destroy(cmt);
+        return -1;
+    }
+
+    start = monotonic_ns();
+    for (index = 0; index < operations; index++) {
+        snprintf(label, sizeof(label), "series-%zu", index % cardinality);
+        result = cmt_counter_inc(counter, index + 2, 1, values);
+        if (result != 0) {
+            cmt_destroy(cmt);
+            return -1;
+        }
+    }
+    elapsed = monotonic_ns() - start;
+
+    printf("benchmark=update cardinality=%zu operations=%zu elapsed_ns=%" PRIu64
+           " ns_per_op=%.2f ops_per_second=%.2f\n",
+           cardinality, operations, elapsed, (double) elapsed / operations,
+           (double) operations * 1000000000.0 / elapsed);
+    cmt_destroy(cmt);
+    return 0;
+}
+
+static int benchmark_prometheus(size_t cardinality, size_t operations)
+{
+    size_t index;
+    size_t bytes = 0;
+    uint64_t start;
+    uint64_t elapsed;
+    cfl_sds_t output;
+    struct cmt *cmt;
+
+    cmt = cmt_create();
+    if (create_series(cmt, cardinality) == NULL) {
+        cmt_destroy(cmt);
+        return -1;
+    }
+
+    start = monotonic_ns();
+    for (index = 0; index < operations; index++) {
+        output = cmt_encode_prometheus_create(cmt, CMT_FALSE);
+        if (output == NULL) {
+            cmt_destroy(cmt);
+            return -1;
+        }
+        bytes += cfl_sds_len(output);
+        cmt_encode_prometheus_destroy(output);
+    }
+    elapsed = monotonic_ns() - start;
+
+    printf("benchmark=prometheus cardinality=%zu operations=%zu bytes=%zu "
+           "elapsed_ns=%" PRIu64 " ns_per_op=%.2f mb_per_second=%.2f\n",
+           cardinality, operations, bytes, elapsed, (double) elapsed / operations,
+           ((double) bytes / (1024.0 * 1024.0)) /
+           ((double) elapsed / 1000000000.0));
+    cmt_destroy(cmt);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    size_t cardinality;
+    size_t operations;
+
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s lookup|update|prometheus CARDINALITY OPERATIONS\n",
+                argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    cardinality = parse_size(argv[2], "cardinality");
+    operations = parse_size(argv[3], "operations");
+    cmt_initialize();
+
+    if (strcmp(argv[1], "lookup") == 0) {
+        return benchmark_lookup(cardinality, operations) == 0 ?
+               EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    if (strcmp(argv[1], "update") == 0) {
+        return benchmark_update(cardinality, operations) == 0 ?
+               EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    if (strcmp(argv[1], "prometheus") == 0) {
+        return benchmark_prometheus(cardinality, operations) == 0 ?
+               EXIT_SUCCESS : EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "unknown benchmark: %s\n", argv[1]);
+    return EXIT_FAILURE;
+}

--- a/benchmarks/run-perf.sh
+++ b/benchmarks/run-perf.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -eu
+
+benchmark=${1:-./build/benchmarks/cmt-benchmark}
+repetitions=${REPETITIONS:-5}
+
+run_repeated()
+{
+    mode=$1
+    cardinality=$2
+    operations=$3
+    iteration=1
+
+    while [ "$iteration" -le "$repetitions" ]; do
+        "$benchmark" "$mode" "$cardinality" "$operations"
+        iteration=$((iteration + 1))
+    done
+}
+
+run_repeated lookup 5000 100000
+run_repeated update 5000 100000
+run_repeated update 1 5000000
+run_repeated prometheus 5000 100
+
+perf stat \
+    -e cycles,instructions,branches,branch-misses,cache-misses \
+    -r "$repetitions" \
+    "$benchmark" lookup 5000 100000

--- a/include/cmetrics/cmt_map.h
+++ b/include/cmetrics/cmt_map.h
@@ -46,6 +46,11 @@ struct cmt_map {
 
     /* Internal lock. Keep this after the established public fields. */
     uint64_t metric_lock;
+    struct cfl_list *metric_buckets;
+    size_t metric_bucket_count;
+    size_t indexed_metric_count;
+    /* Most recently created metric; only changed with the metric list. */
+    struct cmt_metric *last_metric;
 };
 
 struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts,

--- a/include/cmetrics/cmt_metric.h
+++ b/include/cmetrics/cmt_metric.h
@@ -70,6 +70,11 @@ struct cmt_metric {
     uint64_t exp_hist_lock;
     struct cfl_list labels;
     struct cfl_list _head;
+
+    /* Internal lookup index. Keep these after the established public fields. */
+    int hash_indexed;
+    struct cmt_map *map;
+    struct cfl_list _hash_head;
 };
 
 struct cmt_exp_histogram_snapshot {

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -26,6 +26,9 @@
 #include <cmetrics/cmt_summary.h>
 #include <cmetrics/cmt_compat.h>
 
+#define CMT_MAP_INITIAL_BUCKET_COUNT 64
+#define CMT_MAP_BUCKET_LOAD_FACTOR   4
+
 static void map_lock(struct cmt_map *map)
 {
     while (cmt_atomic_compare_exchange(&map->metric_lock, 0, 1) == 0) {
@@ -35,6 +38,59 @@ static void map_lock(struct cmt_map *map)
 static void map_unlock(struct cmt_map *map)
 {
     cmt_atomic_store(&map->metric_lock, 0);
+}
+
+static int metric_index_resize(struct cmt_map *map, size_t bucket_count)
+{
+    size_t index;
+    struct cfl_list *head;
+    struct cfl_list *buckets;
+    struct cmt_metric *metric;
+
+    buckets = calloc(bucket_count, sizeof(struct cfl_list));
+    if (buckets == NULL) {
+        return -1;
+    }
+    for (index = 0; index < bucket_count; index++) {
+        cfl_list_init(&buckets[index]);
+    }
+
+    cfl_list_foreach(head, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        if (metric->hash_indexed) {
+            cfl_list_del(&metric->_hash_head);
+            cfl_list_add(&metric->_hash_head,
+                         &buckets[metric->hash % bucket_count]);
+        }
+    }
+
+    free(map->metric_buckets);
+    map->metric_buckets = buckets;
+    map->metric_bucket_count = bucket_count;
+    return 0;
+}
+
+static void metric_index_add(struct cmt_map *map, struct cmt_metric *metric)
+{
+    if (metric->hash_indexed) {
+        return;
+    }
+
+    if (map->metric_buckets == NULL &&
+        metric_index_resize(map, CMT_MAP_INITIAL_BUCKET_COUNT) != 0) {
+        return;
+    }
+
+    if (map->indexed_metric_count >=
+        map->metric_bucket_count * CMT_MAP_BUCKET_LOAD_FACTOR) {
+        metric_index_resize(map, map->metric_bucket_count * 2);
+    }
+
+    cfl_list_add(&metric->_hash_head,
+                 &map->metric_buckets[metric->hash % map->metric_bucket_count]);
+    metric->hash_indexed = CMT_TRUE;
+    metric->map = map;
+    map->indexed_metric_count++;
 }
 
 struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts, int count, char **labels,
@@ -61,6 +117,13 @@ struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts, int count, char 
     cfl_list_init(&map->label_keys);
     cfl_list_init(&map->metrics);
     cfl_list_init(&map->metric.labels);
+
+    if (count > 0 &&
+        metric_index_resize(map, CMT_MAP_INITIAL_BUCKET_COUNT) != 0) {
+        cmt_errno();
+        cmt_map_destroy(map);
+        return NULL;
+    }
 
     if (count == 0) {
         map->metric_static_set = 1;
@@ -167,10 +230,30 @@ static struct cmt_metric *metric_hash_lookup(struct cmt_map *map, uint64_t hash,
         return &map->metric;
     }
 
+    metric = map->last_metric;
+    if (metric != NULL && metric->hash == hash &&
+        metric_labels_match(metric, labels_count, labels_val)) {
+        return metric;
+    }
+
+    if (map->metric_buckets != NULL) {
+        cfl_list_foreach(head,
+                         &map->metric_buckets[hash % map->metric_bucket_count]) {
+            metric = cfl_list_entry(head, struct cmt_metric, _hash_head);
+            if (metric->hash == hash &&
+                metric_labels_match(metric, labels_count, labels_val)) {
+                return metric;
+            }
+        }
+    }
+
+    /* Decoders can populate the public metric list directly. Search only
+     * entries that have not yet been indexed, then index a successful match. */
     cfl_list_foreach(head, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
-        if (metric->hash == hash &&
+        if (!metric->hash_indexed && metric->hash == hash &&
             metric_labels_match(metric, labels_count, labels_val)) {
+            metric_index_add(map, metric);
             return metric;
         }
     }
@@ -178,7 +261,7 @@ static struct cmt_metric *metric_hash_lookup(struct cmt_map *map, uint64_t hash,
     return NULL;
 }
 
-static struct cmt_metric *map_metric_create(uint64_t hash,
+static struct cmt_metric *map_metric_create(struct cmt_map *map, uint64_t hash,
                                             int labels_count, char **labels_val)
 {
     int i;
@@ -192,8 +275,10 @@ static struct cmt_metric *map_metric_create(uint64_t hash,
         return NULL;
     }
     cfl_list_init(&metric->labels);
+    cfl_list_init(&metric->_hash_head);
     cmt_metric_set_double(metric, 0, 0.0);
     metric->hash = hash;
+    metric->map = map;
 
     for (i = 0; i < labels_count; i++) {
         label = malloc(sizeof(struct cmt_map_label));
@@ -249,6 +334,18 @@ void cmt_map_metric_destroy(struct cmt_metric *metric)
     }
     if (metric->sum_quantiles) {
         free(metric->sum_quantiles);
+    }
+
+    if (metric->hash_indexed) {
+        if (metric->map != NULL) {
+            if (metric->map->last_metric == metric) {
+                metric->map->last_metric = NULL;
+            }
+            if (metric->map->indexed_metric_count > 0) {
+                metric->map->indexed_metric_count--;
+            }
+        }
+        cfl_list_del(&metric->_hash_head);
     }
 
     cfl_list_del(&metric->_head);
@@ -326,11 +423,13 @@ static struct cmt_metric *map_metric_get_unlocked(struct cmt_opts *opts,
     }
 
     /* If the metric has not been found, just create it */
-    metric = map_metric_create(hash, labels_count, labels_val);
+    metric = map_metric_create(map, hash, labels_count, labels_val);
     if (!metric) {
         return NULL;
     }
     cfl_list_add(&metric->_head, &map->metrics);
+    metric_index_add(map, metric);
+    map->last_metric = metric;
     return metric_prepare_storage(map, metric, write_op);
 }
 
@@ -411,6 +510,8 @@ void cmt_map_destroy(struct cmt_map *map)
     if (map->unit != NULL) {
         cfl_sds_destroy(map->unit);
     }
+
+    free(map->metric_buckets);
 
     free(map);
 }


### PR DESCRIPTION
## Summary

- replace full-list metric lookup with a dynamically resized hash-bucket index
- retain exact label comparison inside buckets for collision safety
- lazily index metrics populated directly by decoders
- add an opt-in benchmark executable and repeatable Linux perf runner
- document the benchmark workflow and performance-change requirements

## Performance

With 5,000 series and 100,000 round-robin lookups, median lookup improves from approximately 7,064 ns/op to approximately 66 ns/op, about 105x.

## Validation

- Full unit suite: 20/20 passed
- Five repeated optimized benchmark runs
- Linux perf hardware counters
- git diff validation

## Rebase status

Rebased onto `master` after #284 merged. The PR now contains only the two signed-off performance and benchmark commits.