### PR TITLE
decode: fix Prometheus metric name ownership

### DIFF
--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -68,6 +68,7 @@ struct cmt_decode_prometheus_context_metric {
     size_t label_count;
     cfl_sds_t labels[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
     struct cfl_list samples;
+    char *name_buf;
 };
 
 struct cmt_decode_prometheus_parse_opts {

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -57,21 +57,8 @@ static void reset_context(struct cmt_decode_prometheus_context *context,
     }
 
     if (context->metric.ns) {
-        if ((void *) context->metric.ns != (void *) "") {
-            /* when namespace is empty, "name" contains a pointer to the
-             * allocated string.
-             *
-             * Note : When the metric name doesn't include the namespace
-             * ns is set to a constant empty string and we need to
-             * differentiate that case from the case where an empty
-             * namespace is provided.
-             */
-
-            free(context->metric.ns);
-        }
-        else {
-            free(context->metric.name);
-        }
+        free(context->metric.ns);
+        free(context->metric.name);
     }
 
     cfl_sds_destroy(context->strbuf);
@@ -175,21 +162,21 @@ static int split_metric_name(struct cmt_decode_prometheus_context *context,
     }
     *subsystem = strchr(*ns, '_');
     if (!(*subsystem)) {
-        *name = *ns;
-        *subsystem = "";
-        *ns = "";
+        *name = strdup(*ns);
+        free(*ns);
+        *ns = strdup("");
     }
     else {
         **subsystem = 0;  /* split */
         (*subsystem)++;
         *name = strchr(*subsystem, '_');
         if (!(*name)) {
-            *name = *subsystem;
+            *name = strdup(*subsystem);
             *subsystem = "";
         }
         else {
-            **name = 0;
-            (*name)++;
+            **name = '\0';
+            *name = strdup((*name)++);
         }
     }
     return 0;

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -56,10 +56,7 @@ static void reset_context(struct cmt_decode_prometheus_context *context,
         cfl_sds_destroy(context->metric.labels[i]);
     }
 
-    if (context->metric.ns) {
-        free(context->metric.ns);
-        free(context->metric.name);
-    }
+    free(context->metric.name_buf);
 
     cfl_sds_destroy(context->strbuf);
     context->strbuf = NULL;
@@ -153,30 +150,35 @@ static int split_metric_name(struct cmt_decode_prometheus_context *context,
         cfl_sds_t metric_name, char **ns,
         char **subsystem, char **name)
 {
+    char *name_buf;
+
     /* split the name */
-    *ns = strdup(metric_name);
-    if (!*ns) {
+    name_buf = strdup(metric_name);
+    if (name_buf == NULL) {
         return report_error(context,
                 CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR,
                 "memory allocation failed");
     }
+
+    context->metric.name_buf = name_buf;
+    *ns = name_buf;
     *subsystem = strchr(*ns, '_');
     if (!(*subsystem)) {
-        *name = strdup(*ns);
-        free(*ns);
-        *ns = strdup("");
+        *name = *ns;
+        *subsystem = "";
+        *ns = "";
     }
     else {
         **subsystem = 0;  /* split */
         (*subsystem)++;
         *name = strchr(*subsystem, '_');
         if (!(*name)) {
-            *name = strdup(*subsystem);
+            *name = *subsystem;
             *subsystem = "";
         }
         else {
-            **name = '\0';
-            *name = strdup((*name)++);
+            **name = 0;
+            (*name)++;
         }
     }
     return 0;

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -79,7 +79,7 @@ void test_header_help()
     TEST_CHECK(f->context.metric.type == 0);
     cfl_sds_destroy(f->context.metric.name_orig);
     cfl_sds_destroy(f->context.metric.docstring);
-    free(f->context.metric.ns);
+    free(f->context.metric.name_buf);
 
     destroy(f);
 }
@@ -97,7 +97,7 @@ void test_header_type()
     TEST_CHECK(f->context.metric.type == COUNTER);
     TEST_CHECK(f->context.metric.docstring == NULL);
     cfl_sds_destroy(f->context.metric.name_orig);
-    free(f->context.metric.ns);
+    free(f->context.metric.name_buf);
 
     destroy(f);
 }
@@ -118,7 +118,7 @@ void test_header_help_type()
     TEST_CHECK(f->context.metric.type == SUMMARY);
     cfl_sds_destroy(f->context.metric.name_orig);
     cfl_sds_destroy(f->context.metric.docstring);
-    free(f->context.metric.ns);
+    free(f->context.metric.name_buf);
 
     destroy(f);
 }
@@ -139,9 +139,67 @@ void test_header_type_help()
     TEST_CHECK(f->context.metric.type == GAUGE);
     cfl_sds_destroy(f->context.metric.name_orig);
     cfl_sds_destroy(f->context.metric.docstring);
-    free(f->context.metric.ns);
+    free(f->context.metric.name_buf);
 
     destroy(f);
+}
+
+void test_metric_name_ownership()
+{
+    struct fixture *f;
+
+    f = init(START_HEADER, "# TYPE metric counter\n");
+    TEST_ASSERT(parse(f) == 0);
+    TEST_CHECK(strcmp(f->context.metric.ns, "") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "metric") == 0);
+    TEST_CHECK(f->context.metric.name_buf != NULL);
+    cfl_sds_destroy(f->context.metric.name_orig);
+    free(f->context.metric.name_buf);
+    destroy(f);
+
+    f = init(START_HEADER, "# TYPE namespace_metric counter\n");
+    TEST_ASSERT(parse(f) == 0);
+    TEST_CHECK(strcmp(f->context.metric.ns, "namespace") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "metric") == 0);
+    TEST_CHECK(f->context.metric.name_buf == f->context.metric.ns);
+    cfl_sds_destroy(f->context.metric.name_orig);
+    free(f->context.metric.name_buf);
+    destroy(f);
+}
+
+void test_metric_name_ownership_resets()
+{
+    int status;
+    struct cmt *cmt = NULL;
+    const char *input =
+        "# TYPE metric gauge\n"
+        "metric 1\n"
+        "# TYPE namespace_metric gauge\n"
+        "namespace_metric 2\n"
+        "# TYPE namespace_subsystem_metric gauge\n"
+        "namespace_subsystem_metric 3\n";
+
+    status = cmt_decode_prometheus_create(&cmt, input, 0, NULL);
+    TEST_ASSERT(status == CMT_DECODE_PROMETHEUS_SUCCESS);
+    TEST_ASSERT(cmt != NULL);
+    cmt_decode_prometheus_destroy(cmt);
+}
+
+void test_metric_name_ownership_error_cleanup()
+{
+    int status;
+    struct cmt *cmt = NULL;
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# TYPE metric counter\nmetric {key=", 0, NULL);
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# TYPE namespace_subsystem_metric counter\n"
+            "namespace_subsystem_metric {key=", 0, NULL);
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
 }
 
 struct cmt_decode_prometheus_context_sample *add_empty_sample(struct fixture *f)
@@ -1729,6 +1787,9 @@ TEST_LIST = {
     {"header_type", test_header_type},
     {"header_help_type", test_header_help_type},
     {"header_type_help", test_header_type_help},
+    {"metric_name_ownership", test_metric_name_ownership},
+    {"metric_name_ownership_resets", test_metric_name_ownership_resets},
+    {"metric_name_ownership_error_cleanup", test_metric_name_ownership_error_cleanup},
     {"labels", test_labels},
     {"labels_trailing_comma", test_labels_trailing_comma},
     {"sample", test_sample},


### PR DESCRIPTION
Supersedes #187 with the original author commit preserved and an ownership-safe follow-up implementation.

## Background

The Prometheus decoder split a duplicated metric name into a mixture of owned pointers, interior pointers, and string literals. Cleanup inferred ownership from pointer values, which allowed invalid frees and made allocation behavior difficult to reason about. The issue was originally found by the Fluent Bit fuzzer referenced in #187.

## Changes

- cherry-pick David Korczynski’s original signed-off fix commit, preserving authorship
- add one explicit `name_buf` owner for the duplicated metric-name allocation
- keep namespace, subsystem, and name as non-owning slices into that buffer
- free only the owner during context reset
- avoid the original patch’s extra unchecked `strdup` calls and broken three-component pointer increment
- cover one-, two-, and three-component names
- cover ownership transitions across multiple metrics in one document
- cover cleanup after syntax errors for one- and three-component names
- append the ownership field after established structure fields to preserve existing offsets

## Validation

- full unit suite: 20/20 passed
- focused ownership tests under AddressSanitizer and UndefinedBehaviorSanitizer
- focused ownership tests under Valgrind Memcheck with leak checking
- successful-document reset and final cleanup paths
- syntax-error cleanup paths
- `git diff --check`

Both commits contain DCO sign-offs.