### PR TITLE
workflows: move Debian validation to Bookworm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,15 +59,12 @@ jobs:
           provenance: false
 
   build-debian:
-    name: Debian Buster build to confirm no issues once used downstream
+    name: Debian Bookworm build to confirm no issues once used downstream
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:bookworm
     steps:
       - name: Set up base image dependencies
         run: |
-          # Update sources to use archive.debian.org (Buster reached end-of-life)
-          sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-          sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
           apt-get update
           apt-get install -y build-essential wget make gcc g++ git libcurl4-openssl-dev
 


### PR DESCRIPTION
Supersedes the remaining CI portion of #243.

## Background

#243 combined a Prometheus decoder build refactor with a Debian image update. The build refactor was already merged separately as `f06029c`, so replaying that commit would duplicate completed work.

The Debian job still uses end-of-life Buster and rewrites package sources to `archive.debian.org`. The original Bullseye target is also near the end of its LTS window, so this refresh uses Debian 12 Bookworm instead.

## Changes

- run downstream Debian validation on `debian:bookworm`
- update the job name accordingly
- remove the Buster archive-mirror workaround

## Validation

- workflow YAML parsed successfully
- full local unit suite: 20/20 passed
- `git diff --check`

An exact local container run was attempted, but this environment does not grant access to the Docker daemon. The PR workflow provides the authoritative Bookworm container validation.

Signed-off-by: Eduardo Silva <eduardo@chronosphere.io>