### PR TITLE
msgpack: preserve long metric strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ CMetrics is heavily inspired by the Go Prometheus Client API design:
 
 - https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#section-documentation
 
+Additional design notes:
+
+- [Long metric label handling](docs/label-value-handling.md)
+
 ## License
 
 This program is under the terms of the

--- a/docs/label-value-handling.md
+++ b/docs/label-value-handling.md
@@ -2,10 +2,10 @@
 
 ## Context
 
-CMetrics currently rejects any string longer than 1024 bytes while decoding
-its internal MessagePack representation. The validation is performed by the
-generic string decoder, so it applies not only to label values, but also to
-metric names, namespaces, subsystems, descriptions, and label names.
+Before this fix, CMetrics rejected any string longer than 1024 bytes while
+decoding its internal MessagePack representation. The validation was performed
+by the generic string decoder, so it applied not only to label values, but also
+to metric names, namespaces, subsystems, descriptions, and label names.
 
 This behavior caused
 [fluent/fluent-bit#9297](https://github.com/fluent/fluent-bit/issues/9297): a
@@ -73,6 +73,12 @@ The internal MessagePack decoder should:
 5. Return a distinct resource-limit error with enough context for callers to
    emit a useful diagnostic.
 6. Never silently truncate metric identifiers or labels.
+
+This fix implements those requirements for data-backed CMetrics MessagePack
+decoding. It verifies that all declared string bytes are present before making
+an allocation, then copies the complete value into CMetrics-owned storage. A
+malicious length field therefore cannot trigger an allocation larger than its
+available input, while valid long strings round-trip without modification.
 
 A configurable safety ceiling may be appropriate for callers that process
 untrusted MessagePack. Such a ceiling should apply to decoder resources, be

--- a/docs/label-value-handling.md
+++ b/docs/label-value-handling.md
@@ -1,0 +1,111 @@
+# Long metric label handling
+
+## Context
+
+CMetrics currently rejects any string longer than 1024 bytes while decoding
+its internal MessagePack representation. The validation is performed by the
+generic string decoder, so it applies not only to label values, but also to
+metric names, namespaces, subsystems, descriptions, and label names.
+
+This behavior caused
+[fluent/fluent-bit#9297](https://github.com/fluent/fluent-bit/issues/9297): a
+valid Prometheus scrape containing a `process_command_line` label longer than
+1024 bytes was accepted by the Prometheus parser, but failed during the
+subsequent CMetrics MessagePack round trip. The failure discarded all metrics
+from the scrape without a useful diagnostic.
+
+[PR #224](https://github.com/fluent/cmetrics/pull/224) proposed retaining the
+first 1024 bytes and appending `...` during MessagePack decoding. The issue is
+valid, but that behavior should not be implemented in the generic decoder.
+
+## Why silent truncation is unsafe
+
+Prometheus identifies a time series using its metric name and complete label
+set. Consider two label values with the same 1024-byte prefix:
+
+```text
+process_command_line="<common prefix>A"
+process_command_line="<common prefix>B"
+```
+
+Blindly replacing both suffixes with `...` gives both samples the same series
+identity. This can merge unrelated series and produce incorrect results.
+
+Truncating at a fixed byte offset can also split a multi-byte UTF-8 character.
+Because the generic MessagePack helper decodes every CMetrics string, the same
+policy could silently alter metric names, descriptions, and label names.
+
+Presentation requirements must not be implemented by mutating the internal
+data model during deserialization. An output encoder may abbreviate a value for
+display, but the stored value must remain unchanged.
+
+## Ecosystem behavior
+
+There is no universal 1024-byte limit for Prometheus label values:
+
+- Prometheus accepts label values without a length limit by default. When a
+  `label_value_length_limit` is configured, one violation fails the scrape
+  instead of silently rewriting the value.
+- VictoriaMetrics provides a configurable label-value limit. It ignores an
+  oversized series and reports the event through logs and an internal metric.
+- Grafana Mimir provides configurable `error`, `drop`, and `truncate`
+  strategies. Its truncation strategy includes a hash of the original value so
+  that values with a common prefix remain distinct.
+- OpenTelemetry metric attributes are currently exempt from the general SDK
+  attribute-length limits.
+
+References:
+
+- [Prometheus data model](https://prometheus.io/docs/concepts/data_model/)
+- [Prometheus scrape configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/)
+- [VictoriaMetrics ingestion limits](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/)
+- [Grafana Mimir configuration](https://grafana.com/docs/mimir/latest/configure/configuration-parameters/)
+- [OpenTelemetry attribute limits](https://opentelemetry.io/docs/specs/otel/common/#attribute-limits)
+
+## Recommended CMetrics behavior
+
+The internal MessagePack decoder should:
+
+1. Decode valid strings losslessly by default.
+2. Treat resource limits separately from string contents and metric semantics.
+3. Prevent integer overflow when calculating allocation sizes.
+4. Bound allocations made from untrusted length fields.
+5. Return a distinct resource-limit error with enough context for callers to
+   emit a useful diagnostic.
+6. Never silently truncate metric identifiers or labels.
+
+A configurable safety ceiling may be appropriate for callers that process
+untrusted MessagePack. Such a ceiling should apply to decoder resources, be
+documented in bytes, and reject input explicitly. It must not reinterpret an
+oversized string as valid data with different contents.
+
+If Fluent Bit or another caller needs an ingestion policy, it should be
+implemented above the MessagePack decoder. Useful policies are:
+
+- `preserve`: retain the complete value; this matches Prometheus defaults.
+- `reject`: reject the scrape or batch with a diagnostic.
+- `drop`: discard only the offending series and increment an error counter.
+- `truncate_hash`: truncate on a valid UTF-8 boundary and append a hash derived
+  from the complete value to preserve series identity as far as practical.
+
+The selected policy and limit should be configurable by the component that
+owns ingestion, because CMetrics is also used with OTLP and other formats whose
+requirements differ.
+
+## Regression coverage
+
+An implementation should include tests for:
+
+- Values of 1023, 1024, 1025, 2048, and 65536 bytes.
+- Two values with an identical 1024-byte prefix and different suffixes.
+- UTF-8 characters crossing any configured boundary.
+- Long metric names, descriptions, label names, and label values independently.
+- Multiple fields and metrics after a long string, proving that the MessagePack
+  reader remains synchronized.
+- A declared string length larger than the available input.
+- A declared length near the integer and configured allocation limits.
+- Allocation failure and cleanup paths.
+- End-to-end Prometheus scrape, CMetrics MessagePack encode/decode, and output.
+
+Memory-safety validation should include AddressSanitizer, UndefinedBehaviorSanitizer,
+and Valgrind in addition to the focused unit tests.

--- a/include/cmetrics/cmt_mpack_utils_defs.h
+++ b/include/cmetrics/cmt_mpack_utils_defs.h
@@ -35,6 +35,5 @@
 
 #define CMT_MPACK_MAX_ARRAY_ENTRY_COUNT      65535
 #define CMT_MPACK_MAX_MAP_ENTRY_COUNT        10
-#define CMT_MPACK_MAX_STRING_LENGTH          1024
 
 #endif

--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -114,6 +114,7 @@ int cmt_mpack_consume_uint_tag(mpack_reader_t *reader, uint64_t *output_buffer)
 
 int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer)
 {
+    const char  *string_data;
     uint32_t    string_length;
     mpack_tag_t tag;
 
@@ -137,42 +138,38 @@ int cmt_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffe
 
     string_length = mpack_tag_str_length(&tag);
 
-    /* This validation only applies to cmetrics and its use cases, we know
-     * for a fact that our label names and values are not supposed to be really
-     * long so a huge value here probably means that the data stream got corrupted.
-     */
-
-    if (CMT_MPACK_MAX_STRING_LENGTH < string_length) {
-        return CMT_MPACK_CORRUPT_INPUT_DATA_ERROR;
-    }
-
-    *output_buffer = cfl_sds_create_size(string_length + 1);
-
-    if (NULL == *output_buffer) {
-        return CMT_MPACK_ALLOCATION_ERROR;
-    }
-
-    cfl_sds_set_len(*output_buffer, string_length);
-
-    mpack_read_cstr(reader, *output_buffer, string_length + 1, string_length);
+    /* Validate that the complete string is present before allocating memory
+     * based on its untrusted length field. The data-backed reader used by the
+     * decoder can return the bytes in place without an intermediate copy. */
+    string_data = mpack_read_bytes_inplace(reader, (size_t) string_length);
 
     if (mpack_ok != mpack_reader_error(reader)) {
-        cfl_sds_destroy(*output_buffer);
-
-        *output_buffer = NULL;
-
         return CMT_MPACK_ENGINE_ERROR;
     }
 
     mpack_done_str(reader);
 
     if (mpack_ok != mpack_reader_error(reader)) {
-        cfl_sds_destroy(*output_buffer);
-
-        *output_buffer = NULL;
-
         return CMT_MPACK_ENGINE_ERROR;
     }
+
+    /* CMetrics strings are represented as C strings. Preserve the existing
+     * rejection of embedded NUL bytes while allowing arbitrary valid lengths. */
+    if (NULL != memchr(string_data, '\0', (size_t) string_length)) {
+        return CMT_MPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
+    *output_buffer = cfl_sds_create_size((size_t) string_length);
+
+    if (NULL == *output_buffer) {
+        return CMT_MPACK_ALLOCATION_ERROR;
+    }
+
+    if (string_length > 0) {
+        memcpy(*output_buffer, string_data, (size_t) string_length);
+    }
+
+    cfl_sds_set_len(*output_buffer, (size_t) string_length);
 
     return CMT_MPACK_SUCCESS;
 }

--- a/tests/issues.c
+++ b/tests/issues.c
@@ -24,6 +24,9 @@
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_decode_prometheus.h>
 #include <cmetrics/cmt_encode_prometheus.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_mpack_utils.h>
+#include <mpack/mpack.h>
 
 #include "cmt_tests.h"
 
@@ -91,6 +94,90 @@ void test_issue_54()
     cmt_destroy(cmt1);
 }
 
+static void check_long_label_round_trip(size_t label_length)
+{
+    char                 *label_value;
+    char                 *label_values[1];
+    char                 *label_keys[1] = {"command"};
+    char                 *msgpack_buffer;
+    size_t                msgpack_size;
+    size_t                offset;
+    int                   result;
+    struct cmt           *source;
+    struct cmt           *decoded;
+    struct cmt_counter   *counter;
+    struct cmt_metric    *metric;
+    struct cmt_map_label *label;
+
+    label_value = malloc(label_length + 1);
+    TEST_ASSERT(label_value != NULL);
+
+    memset(label_value, 'a', label_length);
+    label_value[label_length] = '\0';
+    label_values[0] = label_value;
+
+    source = cmt_create();
+    TEST_ASSERT(source != NULL);
+
+    counter = cmt_counter_create(source, "test", "", "long_label",
+                                 "Long label round-trip", 1, label_keys);
+    TEST_ASSERT(counter != NULL);
+    TEST_CHECK(cmt_counter_set(counter, 0, 1, 1, label_values) == 0);
+
+    result = cmt_encode_msgpack_create(source, &msgpack_buffer, &msgpack_size);
+    TEST_ASSERT(result == 0);
+
+    offset = 0;
+    result = cmt_decode_msgpack_create(&decoded, msgpack_buffer, msgpack_size,
+                                       &offset);
+    TEST_ASSERT(result == 0);
+    TEST_CHECK(offset == msgpack_size);
+
+    counter = cfl_list_entry_first(&decoded->counters,
+                                   struct cmt_counter, _head);
+    metric = cfl_list_entry_first(&counter->map->metrics,
+                                  struct cmt_metric, _head);
+    label = cfl_list_entry_first(&metric->labels,
+                                 struct cmt_map_label, _head);
+
+    TEST_CHECK(cfl_sds_len(label->name) == label_length);
+    TEST_CHECK(memcmp(label->name, label_value, label_length) == 0);
+
+    cmt_decode_msgpack_destroy(decoded);
+    cmt_encode_msgpack_destroy(msgpack_buffer);
+    cmt_destroy(source);
+    free(label_value);
+}
+
+void test_long_msgpack_labels()
+{
+    check_long_label_round_trip(1024);
+    check_long_label_round_trip(1025);
+    check_long_label_round_trip(2048);
+    check_long_label_round_trip(65536);
+}
+
+void test_truncated_msgpack_string()
+{
+    char             *output;
+    int               result;
+    mpack_error_t     error;
+    mpack_reader_t    reader;
+    const char        input[] = {
+        (char) 0xdb, (char) 0xff, (char) 0xff, (char) 0xff, (char) 0xff
+    };
+
+    output = NULL;
+    mpack_reader_init_data(&reader, input, sizeof(input));
+
+    result = cmt_mpack_consume_string_tag(&reader, &output);
+    error = mpack_reader_destroy(&reader);
+
+    TEST_CHECK(result == CMT_MPACK_ENGINE_ERROR);
+    TEST_CHECK(error != mpack_ok);
+    TEST_CHECK(output == NULL);
+}
+
 #ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
 
 /* issue: https://github.com/fluent/fluent-bit/issues/10761 */
@@ -123,6 +210,8 @@ void test_prometheus_metric_no_subsystem()
 
 TEST_LIST = {
     {"issue_54", test_issue_54},
+    {"long_msgpack_labels", test_long_msgpack_labels},
+    {"truncated_msgpack_string", test_truncated_msgpack_string},
 #ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
     {"prometheus_metric_no_subsystem", test_prometheus_metric_no_subsystem},
 #endif


### PR DESCRIPTION
## Summary

- remove the arbitrary 1024-byte limit from CMetrics MessagePack strings
- decode long metric labels and other strings losslessly instead of truncating them
- validate that declared string bytes exist before allocating from an untrusted length field
- preserve the existing rejection of embedded NUL bytes
- add round-trip coverage at 1024, 1025, 2048, and 65536 bytes
- add malformed MessagePack coverage for a huge declared length with no payload
- document why silent `...` truncation from #224 can corrupt series identity

## Root cause

The generic MessagePack string helper treated every string longer than 1024 bytes as corrupt. This affected label values, metric names, namespaces, descriptions, and label names. A valid long Prometheus label therefore failed during the internal MessagePack round trip used by Fluent Bit, causing fluent/fluent-bit#9297.

PR #224 proposed truncating long strings. That can collapse distinct label values into one time-series identity and can split UTF-8 characters. This implementation preserves the complete value instead.

## Safety

The decoder reads the declared bytes in place before allocating CMetrics-owned storage. MPack therefore validates the length against the available input first, preventing a malicious short payload with a huge declared length from driving a huge allocation.

## Validation

- all 20 internal unit-test executables pass
- focused issue tests pass under AddressSanitizer and UndefinedBehaviorSanitizer
- focused issue tests pass under Valgrind with zero errors and zero leaks
- `git diff --check`

Closes fluent/fluent-bit#9297
Supersedes #224.