### PR TITLE
core: fix metric lifecycle and encoding correctness

### DIFF
--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -658,6 +658,21 @@ static struct cmt_exp_histogram *exp_histogram_lookup(struct cmt *cmt, struct cm
     return NULL;
 }
 
+static struct cmt_summary *summary_lookup(struct cmt *cmt, struct cmt_opts *opts)
+{
+    struct cmt_summary *summary;
+    struct cfl_list *head;
+
+    cfl_list_foreach(head, &cmt->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+        if (cmt_opts_compare(&summary->opts, opts) == 0) {
+            return summary;
+        }
+    }
+
+    return NULL;
+}
+
 int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter,
                     struct cmt_map *filtered_map)
 {
@@ -856,48 +871,60 @@ int cmt_cat_histogram(struct cmt *cmt, struct cmt_histogram *histogram,
 int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary,
                     struct cmt_map *filtered_map)
 {
-    int i;
+    size_t i;
     int ret;
     char **labels = NULL;
     struct cmt_map *map;
     struct cmt_opts *opts;
     struct cmt_summary *sum;
     double *quantiles;
-    uint64_t timestamp;
-    double summary_sum;
 
     map = summary->map;
     opts = map->opts;
-    timestamp = cmt_metric_get_timestamp(&map->metric);
-
     ret = cmt_cat_copy_label_keys(map, (char **) &labels);
     if (ret == -1) {
         return -1;
     }
 
-    quantiles = calloc(1, sizeof(double) * summary->quantiles_count);
-    for (i = 0; i < summary->quantiles_count; i++) {
-        quantiles[i] = summary->quantiles[i];
+    sum = summary_lookup(cmt, opts);
+    if (sum != NULL) {
+        if (sum->quantiles_count != summary->quantiles_count) {
+            free(labels);
+            return -1;
+        }
+
+        for (i = 0; i < summary->quantiles_count; i++) {
+            if (sum->quantiles[i] != summary->quantiles[i]) {
+                free(labels);
+                return -1;
+            }
+        }
+    }
+    else {
+        quantiles = NULL;
+        if (summary->quantiles_count > 0) {
+            quantiles = calloc(summary->quantiles_count, sizeof(double));
+            if (quantiles == NULL) {
+                free(labels);
+                return -1;
+            }
+            memcpy(quantiles, summary->quantiles,
+                   summary->quantiles_count * sizeof(double));
+        }
+
+        sum = cmt_summary_create(cmt,
+                                 opts->ns, opts->subsystem,
+                                 opts->name, opts->description,
+                                 summary->quantiles_count,
+                                 quantiles,
+                                 map->label_count, labels);
+        free(quantiles);
     }
 
-    /* create summary */
-    sum = cmt_summary_create(cmt,
-                             opts->ns, opts->subsystem,
-                             opts->name, opts->description,
-                             summary->quantiles_count,
-                             quantiles,
-                             map->label_count, labels);
+    free(labels);
     if (!sum) {
-        free(labels);
-        free(quantiles);
         return -1;
     }
-
-    summary_sum = cmt_summary_get_sum_value(&summary->map->metric);
-
-    cmt_summary_set_default(sum, timestamp, quantiles, summary_sum, summary->quantiles_count, map->label_count, labels);
-    free(labels);
-    free(quantiles);
 
     if (filtered_map != NULL) {
         ret = cmt_cat_copy_map(&sum->opts, sum->map, filtered_map);

--- a/src/cmt_encode_prometheus_remote_write.c
+++ b/src/cmt_encode_prometheus_remote_write.c
@@ -735,6 +735,11 @@ static int check_staled_timestamp(struct cmt_metric *metric, uint64_t now, uint6
     uint64_t diff;
 
     ts = cmt_metric_get_timestamp(metric);
+
+    if (ts >= now) {
+        return CMT_FALSE;
+    }
+
     diff = now - ts;
 
     return diff > cutoff;
@@ -751,6 +756,7 @@ int pack_basic_type(struct cmt_prometheus_remote_write_context *context,
 
     context->sequence_number++;
     add_metadata = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_ADD_METADATA;
+    result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
 
     now = cfl_time_now();
 
@@ -758,13 +764,14 @@ int pack_basic_type(struct cmt_prometheus_remote_write_context *context,
         if (check_staled_timestamp(&map->metric, now,
                                    CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_THRESHOLD)) {
             /* Skip processing metrics which are staled over the threshold */
-            return CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR;
+            result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
         }
-
-        result = pack_basic_metric_sample(context, map, &map->metric, add_metadata);
-
-        if (result != CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
-            return result;
+        else {
+            result = pack_basic_metric_sample(context, map, &map->metric, add_metadata);
+            if (result != CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+                return result;
+            }
+            add_metadata = CMT_FALSE;
         }
     }
 
@@ -774,7 +781,7 @@ int pack_basic_type(struct cmt_prometheus_remote_write_context *context,
         if (check_staled_timestamp(metric, now,
                                    CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_THRESHOLD)) {
             /* Skip processing metrics which are staled over over the threshold */
-            return CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR;
+            continue;
         }
 
         result = pack_basic_metric_sample(context, map, metric, add_metadata);
@@ -1208,6 +1215,12 @@ int pack_complex_type(struct cmt_prometheus_remote_write_context *context,
 
     if (map->metric_static_set == CMT_TRUE) {
         result = pack_complex_metric_sample(context, map, &map->metric, add_metadata);
+        if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+            result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
+        }
+        else if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+            add_metadata = CMT_FALSE;
+        }
     }
 
     if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
@@ -1216,10 +1229,17 @@ int pack_complex_type(struct cmt_prometheus_remote_write_context *context,
 
             result = pack_complex_metric_sample(context, map, metric, add_metadata);
 
-            if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
-                if (add_metadata == CMT_TRUE) {
-                    add_metadata = CMT_FALSE;
-                }
+            if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
+                continue;
+            }
+
+            if (result != CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+                break;
+            }
+
+            if (add_metadata == CMT_TRUE) {
+                add_metadata = CMT_FALSE;
             }
         }
     }
@@ -1266,6 +1286,7 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
         result = pack_basic_type(&context, counter->map);
 
         if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+            result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
             continue;
         }
 
@@ -1281,6 +1302,7 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
             result = pack_basic_type(&context, gauge->map);
 
             if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
                 continue;
             }
 
@@ -1294,10 +1316,15 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
         /* Untyped */
         cfl_list_foreach(head, &cmt->untypeds) {
             untyped = cfl_list_entry(head, struct cmt_untyped, _head);
-            pack_basic_type(&context, untyped->map);
+            result = pack_basic_type(&context, untyped->map);
 
             if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
                 continue;
+            }
+
+            if (result != CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS) {
+                break;
             }
         }
     }
@@ -1309,6 +1336,7 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
             result = pack_complex_type(&context, summary->map);
 
             if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
                 continue;
             }
 
@@ -1325,6 +1353,7 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
             result = pack_complex_type(&context, histogram->map);
 
             if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
                 continue;
             }
 
@@ -1341,6 +1370,7 @@ cfl_sds_t cmt_encode_prometheus_remote_write_create(struct cmt *cmt)
             result = pack_complex_type(&context, exp_histogram->map);
 
             if (result == CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_ERROR) {
+                result = CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_SUCCESS;
                 continue;
             }
 

--- a/src/cmt_filter.c
+++ b/src/cmt_filter.c
@@ -186,7 +186,7 @@ static int filter_get_label_index(struct cmt_map *src, const char *label_key)
 
     cfl_list_foreach(head, &src->label_keys) {
         label = cfl_list_entry(head, struct cmt_map_label, _head);
-        if (strncmp(label->name, label_key, strlen(label->name)) == 0) {
+        if (strcmp(label->name, label_key) == 0) {
            return index;
         }
 
@@ -228,7 +228,7 @@ int metrics_check_label_value_existence(struct cmt_metric *metric,
         return CMT_FALSE;
     }
 
-    if (strncmp(label->name, label_value, strlen(label->name)) == 0) {
+    if (strcmp(label->name, label_value) == 0) {
         return CMT_TRUE;
     }
 
@@ -239,27 +239,25 @@ static int metrics_map_drop_label_value_pairs(struct cmt_map *map,
                                               size_t label_index,
                                               const char *label_value)
 {
+    struct cfl_list   *tmp;
     struct cfl_list   *head;
     struct cmt_metric *metric;
+    int                match;
     int                result;
 
     result = CMT_FALSE;
 
-    cfl_list_foreach(head, &map->metrics) {
+    cfl_list_foreach_safe(head, tmp, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
 
-        result = metrics_check_label_value_existence(metric,
-                                                     label_index,
-                                                     label_value);
+        match = metrics_check_label_value_existence(metric,
+                                                    label_index,
+                                                    label_value);
 
-        if (result == CMT_TRUE) {
+        if (match == CMT_TRUE) {
             result = CMT_TRUE;
-            break;
+            cmt_map_metric_destroy(metric);
         }
-    }
-
-    if (result == CMT_TRUE) {
-        cmt_map_metric_destroy(metric);
     }
 
     return result;

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -40,6 +40,19 @@ static void map_unlock(struct cmt_map *map)
     cmt_atomic_store(&map->metric_lock, 0);
 }
 
+static void metric_release_storage(struct cmt_metric *metric)
+{
+    free(metric->hist_buckets);
+    free(metric->exp_hist_positive_buckets);
+    free(metric->exp_hist_negative_buckets);
+    free(metric->sum_quantiles);
+
+    metric->hist_buckets = NULL;
+    metric->exp_hist_positive_buckets = NULL;
+    metric->exp_hist_negative_buckets = NULL;
+    metric->sum_quantiles = NULL;
+}
+
 static int metric_index_resize(struct cmt_map *map, size_t bucket_count)
 {
     size_t index;
@@ -323,18 +336,7 @@ void cmt_map_metric_destroy(struct cmt_metric *metric)
         free(label);
     }
 
-    if (metric->hist_buckets) {
-        free(metric->hist_buckets);
-    }
-    if (metric->exp_hist_positive_buckets) {
-        free(metric->exp_hist_positive_buckets);
-    }
-    if (metric->exp_hist_negative_buckets) {
-        free(metric->exp_hist_negative_buckets);
-    }
-    if (metric->sum_quantiles) {
-        free(metric->sum_quantiles);
-    }
+    metric_release_storage(metric);
 
     if (metric->hash_indexed) {
         if (metric->map != NULL) {
@@ -487,24 +489,7 @@ void cmt_map_destroy(struct cmt_map *map)
     if (map->metric_static_set) {
         metric = &map->metric;
 
-        if (map->type == CMT_HISTOGRAM) {
-            if (metric->hist_buckets) {
-                free(metric->hist_buckets);
-            }
-        }
-        else if (map->type == CMT_EXP_HISTOGRAM) {
-            if (metric->exp_hist_positive_buckets) {
-                free(metric->exp_hist_positive_buckets);
-            }
-            if (metric->exp_hist_negative_buckets) {
-                free(metric->exp_hist_negative_buckets);
-            }
-        }
-        else if (map->type == CMT_SUMMARY) {
-            if (metric->sum_quantiles) {
-                free(metric->sum_quantiles);
-            }
-        }
+        metric_release_storage(metric);
     }
 
     if (map->unit != NULL) {
@@ -549,6 +534,14 @@ void cmt_map_metrics_expire(struct cmt_map *map, uint64_t expiration)
     struct cmt_metric *metric;
 
     map_lock(map);
+
+    if (map->metric_static_set && map->metric.timestamp < expiration) {
+        metric_release_storage(&map->metric);
+        memset(&map->metric, 0, sizeof(struct cmt_metric));
+        cfl_list_init(&map->metric.labels);
+        map->metric_static_set = CMT_FALSE;
+    }
+
     cfl_list_foreach_safe(head, tmp, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
         if (metric->timestamp < expiration) {

--- a/tests/cat.c
+++ b/tests/cat.c
@@ -24,6 +24,7 @@
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_exp_histogram.h>
 #include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_cat.h>
@@ -668,6 +669,92 @@ void test_exp_histogram_preserves_aggregation_type()
     cmt_destroy(dst);
 }
 
+void test_summary_concatenation_preserves_series()
+{
+    int                   ret;
+    int                   found_first;
+    int                   found_second;
+    double                quantiles[] = {0.5, 0.9};
+    double                values[] = {5.0, 9.0};
+    struct cfl_list      *head;
+    struct cfl_list      *label_head;
+    struct cmt           *dst;
+    struct cmt           *src_first;
+    struct cmt           *src_second;
+    struct cmt_summary   *summary;
+    struct cmt_metric    *metric;
+    struct cmt_map_label *label;
+
+    dst = cmt_create();
+    src_first = cmt_create();
+    src_second = cmt_create();
+    TEST_ASSERT(dst != NULL);
+    TEST_ASSERT(src_first != NULL);
+    TEST_ASSERT(src_second != NULL);
+
+    summary = cmt_summary_create(src_first, "test", "cat", "summary",
+                                 "Summary concatenation", 2, quantiles,
+                                 1, (char *[]) {"kind"});
+    TEST_ASSERT(summary != NULL);
+    ret = cmt_summary_set_default(summary, 10, values, 14.0, 7,
+                                  1, (char *[]) {"first"});
+    TEST_ASSERT(ret == 0);
+
+    ret = cmt_cat(dst, src_first);
+    TEST_ASSERT(ret == 0);
+    TEST_CHECK(cfl_list_size(&dst->summaries) == 1);
+
+    summary = cfl_list_entry_first(&dst->summaries,
+                                   struct cmt_summary, _head);
+    TEST_CHECK(cfl_list_size(&summary->map->metrics) == 1);
+
+    metric = cfl_list_entry_first(&summary->map->metrics,
+                                  struct cmt_metric, _head);
+    label = cfl_list_entry_first(&metric->labels,
+                                 struct cmt_map_label, _head);
+    TEST_CHECK(strcmp(label->name, "first") == 0);
+    TEST_CHECK(cmt_summary_get_count_value(metric) == 7);
+
+    summary = cmt_summary_create(src_second, "test", "cat", "summary",
+                                 "Summary concatenation", 2, quantiles,
+                                 1, (char *[]) {"kind"});
+    TEST_ASSERT(summary != NULL);
+    ret = cmt_summary_set_default(summary, 20, values, 18.0, 9,
+                                  1, (char *[]) {"second"});
+    TEST_ASSERT(ret == 0);
+
+    ret = cmt_cat(dst, src_second);
+    TEST_ASSERT(ret == 0);
+    TEST_CHECK(cfl_list_size(&dst->summaries) == 1);
+
+    summary = cfl_list_entry_first(&dst->summaries,
+                                   struct cmt_summary, _head);
+    TEST_CHECK(cfl_list_size(&summary->map->metrics) == 2);
+
+    found_first = CMT_FALSE;
+    found_second = CMT_FALSE;
+    cfl_list_foreach(head, &summary->map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        label_head = metric->labels.next;
+        label = cfl_list_entry(label_head, struct cmt_map_label, _head);
+
+        TEST_CHECK(strcmp(label->name, "kind") != 0);
+        if (strcmp(label->name, "first") == 0) {
+            found_first = CMT_TRUE;
+        }
+        else if (strcmp(label->name, "second") == 0) {
+            found_second = CMT_TRUE;
+        }
+    }
+
+    TEST_CHECK(found_first == CMT_TRUE);
+    TEST_CHECK(found_second == CMT_TRUE);
+
+    cmt_destroy(src_second);
+    cmt_destroy(src_first);
+    cmt_destroy(dst);
+}
+
 TEST_LIST = {
     {"cat", test_cat},
     {"duplicate_metrics", test_duplicate_metrics},
@@ -676,5 +763,6 @@ TEST_LIST = {
     {"histogram_empty_to_populated", test_histogram_empty_to_populated},
     {"histogram_populated_to_empty", test_histogram_populated_to_empty},
     {"exp_histogram_preserves_aggregation_type", test_exp_histogram_preserves_aggregation_type},
+    {"summary_concatenation_preserves_series", test_summary_concatenation_preserves_series},
     { 0 }
 };

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -978,6 +978,201 @@ void test_prometheus_remote_write_with_outdated_timestamps()
     cmt_destroy(cmt);
 }
 
+static int remote_write_contains_series(Prometheus__WriteRequest *request,
+                                        const char *metric_name,
+                                        const char *label_name,
+                                        const char *label_value)
+{
+    size_t series_index;
+    size_t label_index;
+    int metric_matches;
+    int label_matches;
+    Prometheus__Label *label;
+
+    for (series_index = 0; series_index < request->n_timeseries; series_index++) {
+        metric_matches = CMT_FALSE;
+        label_matches = label_name == NULL;
+
+        for (label_index = 0;
+             label_index < request->timeseries[series_index]->n_labels;
+             label_index++) {
+            label = request->timeseries[series_index]->labels[label_index];
+            if (label == NULL || label->name == NULL || label->value == NULL) {
+                continue;
+            }
+
+            if (strcmp(label->name, "__name__") == 0 &&
+                strcmp(label->value, metric_name) == 0) {
+                metric_matches = CMT_TRUE;
+            }
+
+            if (label_name != NULL && strcmp(label->name, label_name) == 0 &&
+                strcmp(label->value, label_value) == 0) {
+                label_matches = CMT_TRUE;
+            }
+        }
+
+        if (metric_matches && label_matches) {
+            return CMT_TRUE;
+        }
+    }
+
+    return CMT_FALSE;
+}
+
+static Prometheus__WriteRequest *decode_remote_write_payload(cfl_sds_t payload)
+{
+    if (payload == NULL) {
+        return NULL;
+    }
+
+    return prometheus__write_request__unpack(NULL, cfl_sds_len(payload),
+                                             (uint8_t *) payload);
+}
+
+void test_prometheus_remote_write_skips_only_stale_samples()
+{
+    uint64_t                  now;
+    cfl_sds_t                 payload;
+    struct cmt               *cmt;
+    struct cmt_counter       *counter;
+    Prometheus__WriteRequest *request;
+
+    now = cfl_time_now();
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+
+    counter = cmt_counter_create(cmt, "test", "remote", "mixed",
+                                 "Mixed timestamp samples", 1,
+                                 (char *[]) {"state"});
+    TEST_ASSERT(counter != NULL);
+    TEST_ASSERT(cmt_counter_set(counter,
+                               now - CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_THRESHOLD - 1,
+                               1, 1, (char *[]) {"stale"}) == 0);
+    TEST_ASSERT(cmt_counter_set(counter, now, 2, 1,
+                               (char *[]) {"fresh"}) == 0);
+
+    payload = cmt_encode_prometheus_remote_write_create(cmt);
+    request = decode_remote_write_payload(payload);
+    TEST_ASSERT(request != NULL);
+    TEST_CHECK(remote_write_contains_series(request, "test_remote_mixed",
+                                            "state", "stale") == CMT_FALSE);
+    TEST_CHECK(remote_write_contains_series(request, "test_remote_mixed",
+                                            "state", "fresh") == CMT_TRUE);
+
+    prometheus__write_request__free_unpacked(request, NULL);
+    cmt_encode_prometheus_remote_write_destroy(payload);
+    cmt_destroy(cmt);
+}
+
+void test_prometheus_remote_write_continues_after_stale_family()
+{
+    uint64_t                  now;
+    cfl_sds_t                 payload;
+    struct cmt               *cmt;
+    struct cmt_counter       *counter;
+    struct cmt_gauge         *gauge;
+    Prometheus__WriteRequest *request;
+
+    now = cfl_time_now();
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+
+    counter = cmt_counter_create(cmt, "test", "remote", "stale_counter",
+                                 "Stale counter", 0, NULL);
+    TEST_ASSERT(counter != NULL);
+    TEST_ASSERT(cmt_counter_set(counter,
+                               now - CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_THRESHOLD - 1,
+                               1, 0, NULL) == 0);
+
+    gauge = cmt_gauge_create(cmt, "test", "remote", "fresh_gauge",
+                             "Fresh gauge", 0, NULL);
+    TEST_ASSERT(gauge != NULL);
+    TEST_ASSERT(cmt_gauge_set(gauge, now, 2, 0, NULL) == 0);
+
+    payload = cmt_encode_prometheus_remote_write_create(cmt);
+    request = decode_remote_write_payload(payload);
+    TEST_ASSERT(request != NULL);
+    TEST_CHECK(remote_write_contains_series(request, "test_remote_stale_counter",
+                                            NULL, NULL) == CMT_FALSE);
+    TEST_CHECK(remote_write_contains_series(request, "test_remote_fresh_gauge",
+                                            NULL, NULL) == CMT_TRUE);
+
+    prometheus__write_request__free_unpacked(request, NULL);
+    cmt_encode_prometheus_remote_write_destroy(payload);
+    cmt_destroy(cmt);
+}
+
+void test_prometheus_remote_write_preserves_future_samples()
+{
+    uint64_t                  now;
+    cfl_sds_t                 payload;
+    struct cmt               *cmt;
+    struct cmt_counter       *counter;
+    Prometheus__WriteRequest *request;
+
+    now = cfl_time_now();
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+
+    counter = cmt_counter_create(cmt, "test", "remote", "future",
+                                 "Future timestamp", 0, NULL);
+    TEST_ASSERT(counter != NULL);
+    TEST_ASSERT(cmt_counter_set(counter, now + 1000000000, 1, 0, NULL) == 0);
+
+    payload = cmt_encode_prometheus_remote_write_create(cmt);
+    request = decode_remote_write_payload(payload);
+    TEST_ASSERT(request != NULL);
+    TEST_CHECK(remote_write_contains_series(request, "test_remote_future",
+                                            NULL, NULL) == CMT_TRUE);
+
+    prometheus__write_request__free_unpacked(request, NULL);
+    cmt_encode_prometheus_remote_write_destroy(payload);
+    cmt_destroy(cmt);
+}
+
+void test_prometheus_remote_write_skips_only_stale_histograms()
+{
+    uint64_t                      now;
+    cfl_sds_t                     payload;
+    struct cmt                   *cmt;
+    struct cmt_histogram         *histogram;
+    struct cmt_histogram_buckets *buckets;
+    Prometheus__WriteRequest     *request;
+
+    now = cfl_time_now();
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+
+    buckets = cmt_histogram_buckets_create(1, 1.0);
+    TEST_ASSERT(buckets != NULL);
+    histogram = cmt_histogram_create(cmt, "test", "remote", "mixed_histogram",
+                                     "Mixed histogram timestamps", buckets,
+                                     1, (char *[]) {"state"});
+    TEST_ASSERT(histogram != NULL);
+
+    TEST_ASSERT(cmt_histogram_observe(
+                    histogram,
+                    now - CMT_ENCODE_PROMETHEUS_REMOTE_WRITE_CUTOFF_THRESHOLD - 1,
+                    0.5, 1, (char *[]) {"stale"}) == 0);
+    TEST_ASSERT(cmt_histogram_observe(histogram, now, 0.5, 1,
+                                     (char *[]) {"fresh"}) == 0);
+
+    payload = cmt_encode_prometheus_remote_write_create(cmt);
+    request = decode_remote_write_payload(payload);
+    TEST_ASSERT(request != NULL);
+    TEST_CHECK(remote_write_contains_series(
+                   request, "test_remote_mixed_histogram_bucket",
+                   "state", "stale") == CMT_FALSE);
+    TEST_CHECK(remote_write_contains_series(
+                   request, "test_remote_mixed_histogram_bucket",
+                   "state", "fresh") == CMT_TRUE);
+
+    prometheus__write_request__free_unpacked(request, NULL);
+    cmt_encode_prometheus_remote_write_destroy(payload);
+    cmt_destroy(cmt);
+}
+
 void test_opentelemetry()
 {
     cfl_sds_t payload;
@@ -1615,6 +1810,10 @@ TEST_LIST = {
     {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
     {"prometheus_remote_write",        test_prometheus_remote_write},
     {"prometheus_remote_write_old_cmt",test_prometheus_remote_write_with_outdated_timestamps},
+    {"prometheus_remote_write_skips_only_stale_samples", test_prometheus_remote_write_skips_only_stale_samples},
+    {"prometheus_remote_write_continues_after_stale_family", test_prometheus_remote_write_continues_after_stale_family},
+    {"prometheus_remote_write_preserves_future_samples", test_prometheus_remote_write_preserves_future_samples},
+    {"prometheus_remote_write_skips_only_stale_histograms", test_prometheus_remote_write_skips_only_stale_histograms},
     {"cmt_msgpack_stability",          test_cmt_to_msgpack_stability},
     {"cmt_msgpack_integrity",          test_cmt_to_msgpack_integrity},
     {"cmt_msgpack_labels",             test_cmt_to_msgpack_labels},

--- a/tests/expire.c
+++ b/tests/expire.c
@@ -309,6 +309,50 @@ void test_expire_off_by_one()
     cmt_destroy(cmt);
 }
 
+void test_expire_static_metrics()
+{
+    uint64_t                      ts;
+    struct cmt                   *cmt;
+    struct cmt_counter           *counter;
+    struct cmt_histogram         *histogram;
+    struct cmt_histogram_buckets *buckets;
+
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+    ts = cfl_time_now();
+
+    counter = cmt_counter_create(cmt, "test", "expire", "static_counter",
+                                 "Static counter expiration", 0, NULL);
+    TEST_ASSERT(counter != NULL);
+    TEST_ASSERT(cmt_counter_set(counter, ts - 10, 3, 0, NULL) == 0);
+
+    buckets = cmt_histogram_buckets_create(2, 1.0, 5.0);
+    TEST_ASSERT(buckets != NULL);
+    histogram = cmt_histogram_create(cmt, "test", "expire", "static_histogram",
+                                     "Static histogram expiration", buckets,
+                                     0, NULL);
+    TEST_ASSERT(histogram != NULL);
+    TEST_ASSERT(cmt_histogram_observe(histogram, ts - 10, 2.0,
+                                     0, NULL) == 0);
+    TEST_CHECK(histogram->map->metric.hist_buckets != NULL);
+
+    cmt_expire(cmt, ts - 1);
+
+    TEST_CHECK(counter->map->metric_static_set == CMT_FALSE);
+    TEST_CHECK(histogram->map->metric_static_set == CMT_FALSE);
+    TEST_CHECK(histogram->map->metric.hist_buckets == NULL);
+
+    TEST_ASSERT(cmt_counter_set(counter, ts, 4, 0, NULL) == 0);
+    TEST_ASSERT(cmt_histogram_observe(histogram, ts, 2.0, 0, NULL) == 0);
+    TEST_CHECK(counter->map->metric_static_set == CMT_TRUE);
+    TEST_CHECK(histogram->map->metric_static_set == CMT_TRUE);
+    TEST_CHECK(histogram->map->metric.hist_buckets != NULL);
+    TEST_CHECK(cmt_metric_get_timestamp(&counter->map->metric) == ts);
+    TEST_CHECK(cmt_metric_get_timestamp(&histogram->map->metric) == ts);
+
+    cmt_destroy(cmt);
+}
+
 TEST_LIST = {
     {"expire_counter"    ,   test_expire_counter},
     {"expire_gauge",         test_expire_gauge},
@@ -317,5 +361,6 @@ TEST_LIST = {
     {"expire_untyped",       test_expire_untyped},
     {"expire_exp_histogram", test_epxire_exp_histogram},
     {"expire_off_by_one",    test_expire_off_by_one},
+    {"expire_static_metrics", test_expire_static_metrics},
     { 0 }
 };

--- a/tests/filter.c
+++ b/tests/filter.c
@@ -452,9 +452,60 @@ void test_filter_with_label_key_value_pairs()
     cmt_destroy(cmt6);
 }
 
+void test_filter_label_pair_exact_and_all_matches()
+{
+    int                 ret;
+    cfl_sds_t           text;
+    struct cmt         *src;
+    struct cmt         *prefix_result;
+    struct cmt         *exact_result;
+    struct cmt_counter *counter;
+
+    src = cmt_create();
+    prefix_result = cmt_create();
+    exact_result = cmt_create();
+    TEST_ASSERT(src != NULL);
+    TEST_ASSERT(prefix_result != NULL);
+    TEST_ASSERT(exact_result != NULL);
+
+    counter = cmt_counter_create(src, "test", "filter", "requests",
+                                 "Filter exact label pairs", 2,
+                                 (char *[]) {"host", "zone"});
+    TEST_ASSERT(counter != NULL);
+
+    TEST_ASSERT(cmt_counter_set(counter, 1, 1, 2,
+                               (char *[]) {"prod", "a"}) == 0);
+    TEST_ASSERT(cmt_counter_set(counter, 1, 2, 2,
+                               (char *[]) {"prod", "b"}) == 0);
+    TEST_ASSERT(cmt_counter_set(counter, 1, 3, 2,
+                               (char *[]) {"production", "c"}) == 0);
+
+    ret = cmt_filter_with_label_pair(prefix_result, src, "hostname", "prod");
+    TEST_ASSERT(ret == CMT_FILTER_SUCCESS);
+    text = cmt_encode_text_create(prefix_result);
+    TEST_ASSERT(text != NULL);
+    TEST_CHECK(strstr(text, "host=\"prod\",zone=\"a\"") != NULL);
+    TEST_CHECK(strstr(text, "host=\"prod\",zone=\"b\"") != NULL);
+    TEST_CHECK(strstr(text, "host=\"production\",zone=\"c\"") != NULL);
+    cmt_encode_text_destroy(text);
+
+    ret = cmt_filter_with_label_pair(exact_result, src, "host", "prod");
+    TEST_ASSERT(ret == CMT_FILTER_SUCCESS);
+    text = cmt_encode_text_create(exact_result);
+    TEST_ASSERT(text != NULL);
+    TEST_CHECK(strstr(text, "host=\"prod\"") == NULL);
+    TEST_CHECK(strstr(text, "host=\"production\",zone=\"c\"") != NULL);
+    cmt_encode_text_destroy(text);
+
+    cmt_destroy(exact_result);
+    cmt_destroy(prefix_result);
+    cmt_destroy(src);
+}
+
 
 TEST_LIST = {
     {"filter", test_filter},
     {"filter_with_label_pair", test_filter_with_label_key_value_pairs},
+    {"filter_label_pair_exact_and_all_matches", test_filter_label_pair_exact_and_all_matches},
     { 0 }
 };


### PR DESCRIPTION
## Summary

- concatenate compatible summaries into one family without creating phantom label values
- require exact label-pair matches and remove every matching series
- skip stale Prometheus Remote Write samples individually while preserving fresh and future-dated samples
- continue encoding later metric families after an expired family
- propagate untyped Remote Write encoder failures correctly
- expire static/no-label samples and release their type-specific storage safely
- add focused regression coverage for every corrected path

## Root causes

Summary concatenation initialized a synthetic sample using label keys as values and always created a new summary family. Label-pair filtering used prefix comparisons and stopped after its first match. Remote Write used unsigned timestamp subtraction and returned cutoff status at the family level, which could suppress fresh samples and all later metric types. Expiration traversed only the dynamic metric list and ignored the static metric stored directly in each map.

## User impact

The fixes prevent phantom or duplicate summary series, incomplete filtering, silent loss of valid Remote Write data, incorrect rejection of future timestamps, and retention of expired no-label metrics. Static complex metrics release their allocated bucket or quantile storage before they are reset and can be populated again after expiration.

## Validation

- all 20 internal test executables pass in a normal build
- all 20 internal test executables pass with AddressSanitizer and UndefinedBehaviorSanitizer
- focused concatenation, filtering, expiration, and encoding suites pass under Valgrind
- Valgrind reports zero errors and no memory left allocated
- `git diff --check`

All commits include `Signed-off-by` trailers.