### PR TITLE
opentelemetry: reduce metrics encoding allocation churn

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,8 +22,13 @@ REPETITIONS=5 benchmarks/run-perf.sh \
 The executable also accepts individual workloads:
 
 ```text
-cmt-benchmark lookup|update|prometheus CARDINALITY OPERATIONS
+cmt-benchmark lookup|update|prometheus|opentelemetry|opentelemetry-mixed CARDINALITY OPERATIONS
 ```
+
+The `opentelemetry` workload repeatedly encodes a labeled counter with the
+requested number of series. The `opentelemetry-mixed` workload creates that
+many counter, gauge, and histogram series to exercise scalar and aggregate
+protobuf data points in the same request.
 
 Compare medians from at least five alternating before/after runs. Keep CPU
 frequency policy, compiler, flags, machine load, and input parameters fixed.

--- a/benchmarks/benchmark.c
+++ b/benchmarks/benchmark.c
@@ -7,7 +7,10 @@
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_encode_opentelemetry.h>
 #include <cmetrics/cmt_encode_prometheus.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_histogram.h>
 
 static uint64_t monotonic_ns(void)
 {
@@ -56,6 +59,45 @@ static struct cmt_counter *create_series(struct cmt *cmt, size_t cardinality)
     }
 
     return counter;
+}
+
+static int create_mixed_series(struct cmt *cmt, size_t cardinality)
+{
+    size_t index;
+    char label[32];
+    char *values[] = {label};
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_histogram *histogram;
+    struct cmt_histogram_buckets *buckets;
+
+    counter = cmt_counter_create(cmt, "bench", "", "requests_total",
+                                 "benchmark counter", 1,
+                                 (char *[]) {"series"});
+    gauge = cmt_gauge_create(cmt, "bench", "", "queue_depth",
+                             "benchmark gauge", 1,
+                             (char *[]) {"series"});
+    buckets = cmt_histogram_buckets_create(4, 0.01, 0.1, 1.0, 10.0);
+    histogram = cmt_histogram_create(cmt, "bench", "", "latency_seconds",
+                                     "benchmark histogram", buckets, 1,
+                                     (char *[]) {"series"});
+    if (counter == NULL || gauge == NULL || buckets == NULL ||
+        histogram == NULL) {
+        return -1;
+    }
+
+    for (index = 0; index < cardinality; index++) {
+        snprintf(label, sizeof(label), "series-%zu", index);
+        if (cmt_counter_set(counter, index + 1, 1.0, 1, values) != 0 ||
+            cmt_gauge_set(gauge, index + 1, (double) index, 1, values) != 0 ||
+            cmt_histogram_observe(histogram, index + 1,
+                                  (double) (index % 100) / 10.0,
+                                  1, values) != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 static int benchmark_lookup(size_t cardinality, size_t operations)
@@ -169,13 +211,91 @@ static int benchmark_prometheus(size_t cardinality, size_t operations)
     return 0;
 }
 
+static int benchmark_opentelemetry(size_t cardinality, size_t operations)
+{
+    size_t index;
+    size_t bytes;
+    uint64_t start;
+    uint64_t elapsed;
+    cfl_sds_t output;
+    struct cmt *cmt;
+
+    bytes = 0;
+    cmt = cmt_create();
+    if (create_series(cmt, cardinality) == NULL) {
+        cmt_destroy(cmt);
+        return -1;
+    }
+
+    start = monotonic_ns();
+    for (index = 0; index < operations; index++) {
+        output = cmt_encode_opentelemetry_create(cmt);
+        if (output == NULL) {
+            cmt_destroy(cmt);
+            return -1;
+        }
+        bytes += cfl_sds_len(output);
+        cmt_encode_opentelemetry_destroy(output);
+    }
+    elapsed = monotonic_ns() - start;
+
+    printf("benchmark=opentelemetry cardinality=%zu operations=%zu bytes=%zu "
+           "elapsed_ns=%" PRIu64 " ns_per_op=%.2f mb_per_second=%.2f\n",
+           cardinality, operations, bytes, elapsed, (double) elapsed / operations,
+           ((double) bytes / (1024.0 * 1024.0)) /
+           ((double) elapsed / 1000000000.0));
+    cmt_destroy(cmt);
+    return 0;
+}
+
+static int benchmark_opentelemetry_mixed(size_t cardinality, size_t operations)
+{
+    size_t index;
+    size_t bytes;
+    uint64_t start;
+    uint64_t elapsed;
+    cfl_sds_t output;
+    struct cmt *cmt;
+
+    bytes = 0;
+    cmt = cmt_create();
+    if (cmt == NULL || create_mixed_series(cmt, cardinality) != 0) {
+        cmt_destroy(cmt);
+        return -1;
+    }
+
+    start = monotonic_ns();
+    for (index = 0; index < operations; index++) {
+        output = cmt_encode_opentelemetry_create(cmt);
+        if (output == NULL) {
+            cmt_destroy(cmt);
+            return -1;
+        }
+        bytes += cfl_sds_len(output);
+        cmt_encode_opentelemetry_destroy(output);
+    }
+    elapsed = monotonic_ns() - start;
+
+    printf("benchmark=opentelemetry-mixed cardinality=%zu operations=%zu "
+           "bytes=%zu elapsed_ns=%" PRIu64 " ns_per_op=%.2f "
+           "mb_per_second=%.2f\n",
+           cardinality, operations, bytes, elapsed,
+           (double) elapsed / operations,
+           ((double) bytes / (1024.0 * 1024.0)) /
+           ((double) elapsed / 1000000000.0));
+    cmt_destroy(cmt);
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     size_t cardinality;
     size_t operations;
 
     if (argc != 4) {
-        fprintf(stderr, "usage: %s lookup|update|prometheus CARDINALITY OPERATIONS\n",
+        fprintf(stderr, "usage: %s lookup|update|prometheus|opentelemetry|"
+                        "opentelemetry-mixed "
+                        "CARDINALITY OPERATIONS\n",
                 argv[0]);
         return EXIT_FAILURE;
     }
@@ -194,6 +314,14 @@ int main(int argc, char **argv)
     }
     if (strcmp(argv[1], "prometheus") == 0) {
         return benchmark_prometheus(cardinality, operations) == 0 ?
+               EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    if (strcmp(argv[1], "opentelemetry") == 0) {
+        return benchmark_opentelemetry(cardinality, operations) == 0 ?
+               EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    if (strcmp(argv[1], "opentelemetry-mixed") == 0) {
+        return benchmark_opentelemetry_mixed(cardinality, operations) == 0 ?
                EXIT_SUCCESS : EXIT_FAILURE;
     }
 

--- a/benchmarks/run-perf.sh
+++ b/benchmarks/run-perf.sh
@@ -21,8 +21,15 @@ run_repeated lookup 5000 100000
 run_repeated update 5000 100000
 run_repeated update 1 5000000
 run_repeated prometheus 5000 100
+run_repeated opentelemetry 5000 100
+run_repeated opentelemetry-mixed 2000 100
 
 perf stat \
     -e cycles,instructions,branches,branch-misses,cache-misses \
     -r "$repetitions" \
     "$benchmark" lookup 5000 100000
+
+perf stat \
+    -e task-clock,cycles,instructions,branches,branch-misses,cache-misses \
+    -r "$repetitions" \
+    "$benchmark" opentelemetry 5000 500

--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -26,7 +26,44 @@
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_exp_histogram.h>
 #include <cmetrics/cmt_encode_opentelemetry.h>
+#include <cfl/cfl_arena.h>
 #include <inttypes.h>
+
+#define CMT_OTLP_ARENA_INITIAL_CHUNK_SIZE 4096
+#define CMT_OTLP_ARENA_MAX_CHUNK_SIZE     65536
+
+struct cmt_opentelemetry_encoder {
+    struct cmt_opentelemetry_context context;
+    struct cfl_arena                 *arena;
+};
+
+/*
+ * Data points and their label attributes remain immutable and live until the
+ * protobuf request has been packed. Allocate that temporary object graph from
+ * one arena and release it after packing. The returned SDS and metadata-owned
+ * objects remain heap-backed and retain their existing ownership rules.
+ */
+
+static struct cfl_arena *get_context_arena(
+    struct cmt_opentelemetry_context *context)
+{
+    struct cmt_opentelemetry_encoder *encoder;
+
+    encoder = (struct cmt_opentelemetry_encoder *) context;
+
+    return encoder->arena;
+}
+
+static struct cfl_arena *create_encoder_arena(void)
+{
+    struct cfl_arena_options options;
+
+    cfl_arena_options_init(&options);
+    options.chunk_size = CMT_OTLP_ARENA_INITIAL_CHUNK_SIZE;
+    options.maximum_chunk_size = CMT_OTLP_ARENA_MAX_CHUNK_SIZE;
+
+    return cfl_arena_create_with_options(&options);
+}
 
 static Opentelemetry__Proto__Metrics__V1__ScopeMetrics **
     initialize_scope_metrics_list(
@@ -746,15 +783,12 @@ static int is_metric_empty(struct cmt_map *map);
 static size_t get_metric_count(struct cmt *cmt);
 
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *
-    initialize_summary_value_at_quantile(
-    double quantile, double value);
-
-static void destroy_summary_value_at_quantile(
-    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *value);
+    initialize_summary_value_at_quantile(struct cfl_arena *arena,
+                                         double quantile, double value);
 
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **
-    initialize_summary_value_at_quantile_list(
-    size_t element_count);
+    initialize_summary_value_at_quantile_list(struct cfl_arena *arena,
+                                              size_t element_count);
 
 static void destroy_summary_value_at_quantile_list(
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list);
@@ -810,14 +844,15 @@ static void destroy_attribute(
     Opentelemetry__Proto__Common__V1__KeyValue *attribute);
 
 static Opentelemetry__Proto__Common__V1__KeyValue *
-    initialize_string_attribute(char *key, char *value);
+    initialize_string_attribute(struct cfl_arena *arena,
+                                char *key, char *value);
 
 static void destroy_attribute_list(
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list);
 
 static Opentelemetry__Proto__Common__V1__KeyValue **
-    initialize_attribute_list(
-    size_t element_count);
+    initialize_attribute_list(struct cfl_arena *arena,
+                              size_t element_count);
 
 static void destroy_numerical_data_point(
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point);
@@ -848,16 +883,16 @@ static void destroy_exponential_histogram_data_point_list(
     Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint **data_point_list);
 
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
-    initialize_numerical_data_point(
-    uint64_t start_time,
+    initialize_numerical_data_point(struct cfl_arena *arena,
+                                    uint64_t start_time,
     uint64_t timestamp,
     struct cmt_metric *sample,
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
     size_t attribute_count);
 
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
-    initialize_summary_data_point(
-    uint64_t start_time,
+    initialize_summary_data_point(struct cfl_arena *arena,
+                                  uint64_t start_time,
     uint64_t timestamp,
     uint64_t count,
     double sum,
@@ -869,8 +904,8 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
     size_t attribute_count);
 
 static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
-    initialize_histogram_data_point(
-    uint64_t start_time,
+    initialize_histogram_data_point(struct cfl_arena *arena,
+                                    uint64_t start_time,
     uint64_t timestamp,
     uint64_t count,
     double sum,
@@ -1904,33 +1939,18 @@ static Opentelemetry__Proto__Metrics__V1__ScopeMetrics **initialize_scope_metric
 
 static void destroy_attribute(Opentelemetry__Proto__Common__V1__KeyValue *attribute)
 {
-    if (attribute != NULL) {
-        if (attribute->value != NULL) {
-            if (attribute->value->value_case == \
-                OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE) {
-                if (is_string_releaseable(attribute->value->string_value)) {
-                    cfl_sds_destroy(attribute->value->string_value);
-                }
-            }
-
-            free(attribute->value);
-        }
-
-        if (is_string_releaseable(attribute->key)) {
-            cfl_sds_destroy(attribute->key);
-        }
-
-        free(attribute);
-    }
+    (void) attribute;
 }
 
 static Opentelemetry__Proto__Common__V1__KeyValue *
-    initialize_string_attribute(char *key, char *value)
+    initialize_string_attribute(struct cfl_arena *arena,
+                                char *key, char *value)
 {
     Opentelemetry__Proto__Common__V1__KeyValue *attribute;
 
-    attribute = calloc(1,
-                       sizeof(Opentelemetry__Proto__Common__V1__KeyValue));
+    attribute = cfl_arena_calloc(
+                    arena, 1,
+                    sizeof(Opentelemetry__Proto__Common__V1__KeyValue));
 
     if (attribute == NULL) {
         return NULL;
@@ -1938,8 +1958,9 @@ static Opentelemetry__Proto__Common__V1__KeyValue *
 
     opentelemetry__proto__common__v1__key_value__init(attribute);
 
-    attribute->value = calloc(1,
-                              sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
+    attribute->value = cfl_arena_calloc(
+                           arena, 1,
+                           sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
 
     if (attribute->value == NULL) {
         destroy_attribute(attribute);
@@ -1949,7 +1970,8 @@ static Opentelemetry__Proto__Common__V1__KeyValue *
 
     opentelemetry__proto__common__v1__any_value__init(attribute->value);
 
-    attribute->value->string_value = cfl_sds_create(value);
+    attribute->value->string_value = cfl_arena_strndup(arena, value,
+                                                       strlen(value));
 
     if (attribute->value->string_value == NULL) {
         destroy_attribute(attribute);
@@ -1959,7 +1981,7 @@ static Opentelemetry__Proto__Common__V1__KeyValue *
 
     attribute->value->value_case = OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE;
 
-    attribute->key = cfl_sds_create(key);
+    attribute->key = cfl_arena_strndup(arena, key, strlen(key));
 
     if (attribute->key == NULL) {
         destroy_attribute(attribute);
@@ -1973,29 +1995,18 @@ static Opentelemetry__Proto__Common__V1__KeyValue *
 static void destroy_attribute_list(
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list)
 {
-    size_t element_index;
-
-    if (attribute_list != NULL) {
-        for (element_index = 0 ;
-             attribute_list[element_index] != NULL ;
-             element_index++) {
-            destroy_attribute(attribute_list[element_index]);
-
-            attribute_list[element_index] = NULL;
-        }
-
-        free(attribute_list);
-    }
+    (void) attribute_list;
 }
 
 static Opentelemetry__Proto__Common__V1__KeyValue **
-    initialize_attribute_list(
-    size_t element_count)
+    initialize_attribute_list(struct cfl_arena *arena,
+                              size_t element_count)
 {
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list;
 
-    attribute_list = calloc(element_count + 1,
-                            sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    attribute_list = cfl_arena_calloc(
+                         arena, element_count + 1,
+                         sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
 
     return attribute_list;
 }
@@ -2017,23 +2028,13 @@ static void destroy_numerical_data_point(
 
             free(data_point->exemplars);
         }
-
-        free(data_point);
     }
 }
 
 static void destroy_summary_data_point(
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *data_point)
 {
-    if (data_point != NULL) {
-        destroy_attribute_list(data_point->attributes);
-
-        if (data_point->quantile_values != NULL) {
-            destroy_summary_value_at_quantile_list(data_point->quantile_values);
-        }
-
-        free(data_point);
-    }
+    (void) data_point;
 }
 
 static void destroy_histogram_data_point(
@@ -2042,16 +2043,6 @@ static void destroy_histogram_data_point(
     size_t index;
 
     if (data_point != NULL) {
-        destroy_attribute_list(data_point->attributes);
-
-        if (data_point->bucket_counts != NULL) {
-            free(data_point->bucket_counts);
-        }
-
-        if (data_point->explicit_bounds != NULL) {
-            free(data_point->explicit_bounds);
-        }
-
         if (data_point->exemplars != NULL) {
             for (index = 0; index < data_point->n_exemplars; index++) {
                 if (data_point->exemplars[index] != NULL) {
@@ -2061,8 +2052,6 @@ static void destroy_histogram_data_point(
 
             free(data_point->exemplars);
         }
-
-        free(data_point);
     }
 }
 
@@ -2072,22 +2061,6 @@ static void destroy_exponential_histogram_data_point(
     size_t index;
 
     if (data_point != NULL) {
-        destroy_attribute_list(data_point->attributes);
-
-        if (data_point->positive != NULL) {
-            if (data_point->positive->bucket_counts != NULL) {
-                free(data_point->positive->bucket_counts);
-            }
-            free(data_point->positive);
-        }
-
-        if (data_point->negative != NULL) {
-            if (data_point->negative->bucket_counts != NULL) {
-                free(data_point->negative->bucket_counts);
-            }
-            free(data_point->negative);
-        }
-
         if (data_point->exemplars != NULL) {
             for (index = 0; index < data_point->n_exemplars; index++) {
                 if (data_point->exemplars[index] != NULL) {
@@ -2097,8 +2070,6 @@ static void destroy_exponential_histogram_data_point(
 
             free(data_point->exemplars);
         }
-
-        free(data_point);
     }
 }
 
@@ -2192,8 +2163,8 @@ static void destroy_exponential_histogram_data_point_list(
 }
 
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
-    initialize_numerical_data_point(
-    uint64_t start_time,
+    initialize_numerical_data_point(struct cfl_arena *arena,
+                                    uint64_t start_time,
     uint64_t timestamp,
     struct cmt_metric *sample,
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
@@ -2201,8 +2172,9 @@ static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
 {
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point;
 
-    data_point = calloc(1,
-                        sizeof(Opentelemetry__Proto__Metrics__V1__NumberDataPoint));
+    data_point = cfl_arena_calloc(
+                     arena, 1,
+                     sizeof(Opentelemetry__Proto__Metrics__V1__NumberDataPoint));
 
     if (data_point == NULL) {
         return NULL;
@@ -2237,12 +2209,14 @@ static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
 }
 
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *
-    initialize_summary_value_at_quantile(
-    double quantile, double value)
+    initialize_summary_value_at_quantile(struct cfl_arena *arena,
+                                         double quantile, double value)
 {
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *instance;
 
-    instance = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile));
+    instance = cfl_arena_calloc(
+                   arena, 1,
+                   sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile));
 
     if (instance != NULL) {
         opentelemetry__proto__metrics__v1__summary_data_point__value_at_quantile__init(instance);
@@ -2254,22 +2228,15 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *
     return instance;
 }
 
-static void destroy_summary_value_at_quantile(
-    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *value)
-{
-    if (value != NULL) {
-        free(value);
-    }
-}
-
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **
-    initialize_summary_value_at_quantile_list(
-    size_t element_count)
+    initialize_summary_value_at_quantile_list(struct cfl_arena *arena,
+                                              size_t element_count)
 {
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list;
 
-    list = calloc(element_count + 1,
-                  sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *));
+    list = cfl_arena_calloc(
+               arena, element_count + 1,
+               sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *));
 
     return list;
 }
@@ -2277,26 +2244,14 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **
 static void destroy_summary_value_at_quantile_list(
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list)
 {
-    size_t index;
-
-    if (list != NULL) {
-        for (index = 0 ;
-             list[index] != NULL ;
-             index++) {
-            destroy_summary_value_at_quantile(list[index]);
-
-            list[index] = NULL;
-        }
-
-        free(list);
-    }
+    (void) list;
 }
 
 
 
 static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
-    initialize_summary_data_point(
-    uint64_t start_time,
+    initialize_summary_data_point(struct cfl_arena *arena,
+                                  uint64_t start_time,
     uint64_t timestamp,
     uint64_t count,
     double sum,
@@ -2310,8 +2265,9 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
     Opentelemetry__Proto__Metrics__V1__SummaryDataPoint  *data_point;
     size_t                                                index;
 
-    data_point = calloc(1,
-                        sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint));
+    data_point = cfl_arena_calloc(
+                     arena, 1,
+                     sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint));
 
     if (data_point == NULL) {
         return NULL;
@@ -2326,12 +2282,11 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
     data_point->sum = sum;
     data_point->n_quantile_values = quantile_count;
 
-    data_point->quantile_values = initialize_summary_value_at_quantile_list(quantile_count);
+    data_point->quantile_values =
+        initialize_summary_value_at_quantile_list(arena, quantile_count);
 
     if (data_point->quantile_values == NULL) {
         cmt_errno();
-
-        free(data_point);
 
         return NULL;
     }
@@ -2340,13 +2295,12 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
         if (value_list != NULL) {
             for (index = 0 ; index < quantile_count ; index++) {
                 data_point->quantile_values[index] =
-                    initialize_summary_value_at_quantile(quantile_list[index],
+                    initialize_summary_value_at_quantile(arena,
+                                                         quantile_list[index],
                                                          cmt_math_uint64_to_d64(value_list[index]));
 
                 if (data_point->quantile_values[index] == NULL) {
                     destroy_summary_value_at_quantile_list(data_point->quantile_values);
-
-                    free(data_point);
 
                     return NULL;
                 }
@@ -2361,8 +2315,8 @@ static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
 }
 
 static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
-    initialize_histogram_data_point(
-    uint64_t start_time,
+    initialize_histogram_data_point(struct cfl_arena *arena,
+                                    uint64_t start_time,
     uint64_t timestamp,
     uint64_t count,
     double sum,
@@ -2376,8 +2330,9 @@ static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
     Opentelemetry__Proto__Metrics__V1__HistogramDataPoint  *data_point;
     size_t                                                  index;
 
-    data_point = calloc(1,
-                        sizeof(Opentelemetry__Proto__Metrics__V1__HistogramDataPoint));
+    data_point = cfl_arena_calloc(
+                     arena, 1,
+                     sizeof(Opentelemetry__Proto__Metrics__V1__HistogramDataPoint));
 
     if (data_point == NULL) {
         return NULL;
@@ -2402,12 +2357,11 @@ static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
 
 
     if (bucket_count > 0) {
-        data_point->bucket_counts = calloc(bucket_count, sizeof(uint64_t));
+        data_point->bucket_counts = cfl_arena_calloc(arena, bucket_count,
+                                                     sizeof(uint64_t));
 
         if (data_point->bucket_counts == NULL) {
             cmt_errno();
-
-            free(data_point);
 
             return NULL;
         }
@@ -2422,16 +2376,11 @@ static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
     data_point->n_explicit_bounds = boundary_count;
 
     if (boundary_count > 0) {
-        data_point->explicit_bounds = calloc(boundary_count, sizeof(double));
+        data_point->explicit_bounds = cfl_arena_calloc(arena, boundary_count,
+                                                       sizeof(double));
 
         if (data_point->explicit_bounds == NULL) {
             cmt_errno();
-
-            if (data_point->bucket_counts != NULL) {
-                free(data_point->bucket_counts);
-            }
-
-            free(data_point);
 
             return NULL;
         }
@@ -2944,7 +2893,11 @@ static Opentelemetry__Proto__Metrics__V1__Metric **
 static void destroy_opentelemetry_context(
     struct cmt_opentelemetry_context *context)
 {
+    struct cmt_opentelemetry_encoder *encoder;
+
     if (context != NULL) {
+        encoder = (struct cmt_opentelemetry_encoder *) context;
+
         if (context->scope_metrics_list != NULL) {
             free(context->scope_metrics_list);
         }
@@ -2953,7 +2906,8 @@ static void destroy_opentelemetry_context(
             destroy_metrics_data(context->metrics_data);
         }
 
-        free(context);
+        cfl_arena_destroy(encoder->arena);
+        free(encoder);
     }
 }
 
@@ -3023,6 +2977,7 @@ static struct cmt_opentelemetry_context *initialize_opentelemetry_context(
     struct cfl_kvlist                            *scope_root;
     Opentelemetry__Proto__Resource__V1__Resource *resource;
     struct cmt_opentelemetry_context             *context;
+    struct cmt_opentelemetry_encoder             *encoder;
     size_t                                        resource_count;
     size_t                                        scope_count;
     size_t                                        total_scope_count;
@@ -3039,17 +2994,26 @@ static struct cmt_opentelemetry_context *initialize_opentelemetry_context(
 
     result = CMT_ENCODE_OPENTELEMETRY_SUCCESS;
     total_scope_count = 0;
+    context = NULL;
+    encoder = NULL;
 
-    context = calloc(1, sizeof(struct cmt_opentelemetry_context));
-
-    if (context == NULL) {
+    encoder = calloc(1, sizeof(struct cmt_opentelemetry_encoder));
+    if (encoder == NULL) {
         result = CMT_ENCODE_OPENTELEMETRY_ALLOCATION_ERROR;
 
         goto cleanup;
     }
 
-    memset(context, 0, sizeof(struct cmt_opentelemetry_context));
+    encoder->arena = create_encoder_arena();
+    if (encoder->arena == NULL) {
+        free(encoder);
+        context = NULL;
+        result = CMT_ENCODE_OPENTELEMETRY_ALLOCATION_ERROR;
 
+        goto cleanup;
+    }
+
+    context = &encoder->context;
     context->cmt = cmt;
 
     if (resource_metrics_list != NULL && resource_metrics_list->entry_count > 0) {
@@ -3215,7 +3179,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
         start_timestamp = cmt_metric_get_start_timestamp(sample);
     }
 
-    attribute_list = initialize_attribute_list(attribute_count);
+    attribute_list = initialize_attribute_list(get_context_arena(context),
+                                               attribute_count);
 
     if (attribute_list == NULL) {
         return CMT_ENCODE_OPENTELEMETRY_ALLOCATION_ERROR;
@@ -3224,7 +3189,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     if (map->type == CMT_COUNTER   ||
         map->type == CMT_GAUGE     ||
         map->type == CMT_UNTYPED   ) {
-        data_point = initialize_numerical_data_point(start_timestamp,
+        data_point = initialize_numerical_data_point(get_context_arena(context),
+                                                     start_timestamp,
                                                      cmt_metric_get_timestamp(sample),
                                                      sample,
                                                      attribute_list,
@@ -3233,7 +3199,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     else if (map->type == CMT_SUMMARY) {
         summary = (struct cmt_summary *) map->parent;
 
-        data_point = initialize_summary_data_point(start_timestamp,
+        data_point = initialize_summary_data_point(get_context_arena(context),
+                                                   start_timestamp,
                                                    cmt_metric_get_timestamp(sample),
                                                    cmt_summary_get_count_value(sample),
                                                    cmt_summary_get_sum_value(sample),
@@ -3247,7 +3214,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     else if (map->type == CMT_HISTOGRAM) {
         histogram = (struct cmt_histogram *) map->parent;
 
-        data_point = initialize_histogram_data_point(start_timestamp,
+        data_point = initialize_histogram_data_point(get_context_arena(context),
+                                                     start_timestamp,
                                                      cmt_metric_get_timestamp(sample),
                                                      cmt_metric_hist_get_count_value(sample),
                                                      cmt_metric_hist_get_sum_value(sample),
@@ -3266,7 +3234,9 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
             return CMT_ENCODE_OPENTELEMETRY_DATA_POINT_INIT_ERROR;
         }
 
-        exponential_data_point = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint));
+        exponential_data_point = cfl_arena_calloc(
+                                     get_context_arena(context), 1,
+                                     sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint));
         if (exponential_data_point == NULL) {
             cmt_metric_exp_hist_snapshot_destroy(&snapshot);
             destroy_attribute_list(attribute_list);
@@ -3290,7 +3260,9 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
         }
 
         if (snapshot.positive_count > 0) {
-            positive = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint__Buckets));
+            positive = cfl_arena_calloc(
+                           get_context_arena(context), 1,
+                           sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint__Buckets));
             if (positive == NULL) {
                 cmt_metric_exp_hist_snapshot_destroy(&snapshot);
                 destroy_data_point(exponential_data_point, map->type);
@@ -3300,10 +3272,12 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
             opentelemetry__proto__metrics__v1__exponential_histogram_data_point__buckets__init(positive);
             positive->offset = snapshot.positive_offset;
             positive->n_bucket_counts = snapshot.positive_count;
-            positive->bucket_counts = calloc(snapshot.positive_count, sizeof(uint64_t));
+            positive->bucket_counts = cfl_arena_calloc(
+                                          get_context_arena(context),
+                                          snapshot.positive_count,
+                                          sizeof(uint64_t));
             if (positive->bucket_counts == NULL) {
                 cmt_metric_exp_hist_snapshot_destroy(&snapshot);
-                free(positive);
                 destroy_data_point(exponential_data_point, map->type);
                 return CMT_ENCODE_OPENTELEMETRY_DATA_POINT_INIT_ERROR;
             }
@@ -3313,7 +3287,9 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
         }
 
         if (snapshot.negative_count > 0) {
-            negative = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint__Buckets));
+            negative = cfl_arena_calloc(
+                           get_context_arena(context), 1,
+                           sizeof(Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint__Buckets));
             if (negative == NULL) {
                 cmt_metric_exp_hist_snapshot_destroy(&snapshot);
                 destroy_data_point(exponential_data_point, map->type);
@@ -3323,10 +3299,12 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
             opentelemetry__proto__metrics__v1__exponential_histogram_data_point__buckets__init(negative);
             negative->offset = snapshot.negative_offset;
             negative->n_bucket_counts = snapshot.negative_count;
-            negative->bucket_counts = calloc(snapshot.negative_count, sizeof(uint64_t));
+            negative->bucket_counts = cfl_arena_calloc(
+                                          get_context_arena(context),
+                                          snapshot.negative_count,
+                                          sizeof(uint64_t));
             if (negative->bucket_counts == NULL) {
                 cmt_metric_exp_hist_snapshot_destroy(&snapshot);
-                free(negative);
                 destroy_data_point(exponential_data_point, map->type);
                 return CMT_ENCODE_OPENTELEMETRY_DATA_POINT_INIT_ERROR;
             }
@@ -3350,7 +3328,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     cfl_list_foreach(head, &context->cmt->static_labels->list) {
         static_label = cfl_list_entry(head, struct cmt_label, _head);
 
-        attribute = initialize_string_attribute(static_label->key,
+        attribute = initialize_string_attribute(get_context_arena(context),
+                                                static_label->key,
                                                 static_label->val);
 
         if (attribute == NULL) {
@@ -3410,7 +3389,8 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
             return CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
         }
 
-        attribute = initialize_string_attribute(label_name->name,
+        attribute = initialize_string_attribute(get_context_arena(context),
+                                                label_name->name,
                                                 label_value->name);
 
         if (attribute == NULL) {

--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -44,8 +44,7 @@ struct cmt_opentelemetry_encoder {
  * objects remain heap-backed and retain their existing ownership rules.
  */
 
-static struct cfl_arena *get_context_arena(
-    struct cmt_opentelemetry_context *context)
+static struct cfl_arena *get_context_arena(struct cmt_opentelemetry_context *context)
 {
     struct cmt_opentelemetry_encoder *encoder;
 


### PR DESCRIPTION
## Summary

Reduce OTLP metrics protobuf encoding allocation churn by building temporary datapoints and their label attributes in a per-encode CFL arena.

The protobuf object graph is immutable after construction and remains live only until `get_packed_size()` and `pack()` complete. Arena ownership matches that lifetime: all arena-backed allocations are released together after packing, while the returned SDS payload and independently owned metadata remain heap-backed.

This follows the allocation-lifetime model recently applied to Fluent Bit's OTLP log protobuf encoder.

## Implementation

The arena owns temporary:

- numerical datapoints;
- summary datapoints and quantile entries;
- histogram datapoints, bucket counts, and explicit bounds;
- exponential histogram datapoints and positive/negative buckets;
- datapoint label arrays;
- label `KeyValue` and `AnyValue` objects;
- copied label names and values.

The existing public encoder API and public `cmt_opentelemetry_context` layout are unchanged. A private encoder wrapper owns the public context and arena. The arena uses a 4 KiB initial chunk and grows up to 64 KiB chunks.

Error paths retain their existing behavior. Individually owned exemplar and metadata allocations continue to use their original cleanup rules.

## Benchmark coverage

The benchmark executable now provides two OTLP workloads:

- `opentelemetry`: repeatedly encode a labeled counter with configurable cardinality;
- `opentelemetry-mixed`: repeatedly encode counter, gauge, and histogram series in the same request.

`benchmarks/run-perf.sh` runs both workloads and collects OTLP hardware counters with `perf stat`.

### Methodology

- GCC 13.3
- Release build
- `-O3 -DNDEBUG -g`
- same machine, compiler, flags, and input for both binaries
- ten alternating baseline/optimized runs
- 500 encodes per run
- reported timing is the median in-process elapsed time
- `perf stat` uses five repetitions of 5,000 series × 500 encodes

### Encoding time

| Series per request | Baseline | Arena | Change |
|---:|---:|---:|---:|
| 1 | 0.491 µs | 0.634 µs | 29% slower |
| 100 | 19.873 µs | 16.618 µs | **16.4% faster** |
| 5,000 | 1.734 ms | 1.165 ms | **32.8% faster** |

The one-series result exposes the fixed arena setup cost: approximately 0.14 µs. Batched requests benefit once allocation churn dominates; the 100-series workload is already 16% faster.

The added mixed workload encodes 2,000 counter, gauge, and histogram series in approximately 1.394 ms, producing about 438 KiB per operation. It is included primarily to keep aggregate datapoint performance measurable in future comparisons.

### `perf stat`

5,000 series × 500 encodes:

| Counter | Baseline | Arena | Change |
|---|---:|---:|---:|
| Task clock | 890.6 ms | 597.1 ms | **-33.0%** |
| Cycles | 4.532B | 3.062B | **-32.4%** |
| Instructions | 14.281B | 8.702B | **-39.1%** |
| Branches | 3.057B | 1.877B | **-38.6%** |
| Branch misses | 31.22M | 23.65M | **-24.3%** |
| Cache misses | 17.14M | 12.45M | **-27.4%** |

The five-run task-clock variation was ±0.05% for the optimized binary.

`perf record` attributed 8.84% of baseline cycles directly to `_int_malloc`, with `initialize_string_attribute()` visible beneath the allocation path. `_int_malloc` is no longer among the leading optimized self-time entries; protobuf size calculation and packing become the primary costs.

### Allocations and memory

Valgrind heap accounting for one 5,000-series request:

| Metric | Baseline | Arena | Change |
|---|---:|---:|---:|
| Allocations | 45,036 | 15,059 | **-66.6%** |
| Frees | 45,036 | 15,059 | **-66.6%** |
| Bytes allocated | 3,326,760 | 3,315,590 | -0.3% |
| Leaked bytes | 0 | 0 | none |

Peak RSS measured with `/usr/bin/time -v` fell from 5,972 KiB to 5,464 KiB, an 8.5% reduction.

## Impact

For realistic batched OTLP metric requests, encoding CPU falls by approximately one-third, allocation calls fall by two-thirds, and peak memory falls by about 8.5%. Encoded protobuf contents and the public API are unchanged.

The explicit tradeoff is the fixed ~0.14 µs overhead for a one-series request. It is included here so the batching benefit is not presented as a universal microbenchmark improvement.

## Validation

- Full unit suite: **21/21 passed**
- OTLP-specific suite: **passed**
- Cross-format conversion matrix: **passed**
- Clang AddressSanitizer with leak detection: **passed**
- Valgrind OTLP suite: **0 errors, 0 leaked bytes**
- Valgrind conversion suite: **0 errors, 0 leaked bytes**
- Warning-free build for the changed encoder
- `git diff --check`: **passed**
