### PR TITLE
map: harden metric destruction and summary concatenation

### DIFF
--- a/benchmarks/benchmark.c
+++ b/benchmarks/benchmark.c
@@ -113,6 +113,10 @@ static int benchmark_lookup(size_t cardinality, size_t operations)
     struct cmt_counter *counter;
 
     cmt = cmt_create();
+    if (cmt == NULL) {
+        return -1;
+    }
+
     counter = create_series(cmt, cardinality);
     if (counter == NULL) {
         cmt_destroy(cmt);
@@ -150,6 +154,10 @@ static int benchmark_update(size_t cardinality, size_t operations)
     struct cmt_counter *counter;
 
     cmt = cmt_create();
+    if (cmt == NULL) {
+        return -1;
+    }
+
     counter = create_series(cmt, cardinality);
     if (counter == NULL) {
         cmt_destroy(cmt);
@@ -185,6 +193,10 @@ static int benchmark_prometheus(size_t cardinality, size_t operations)
     struct cmt *cmt;
 
     cmt = cmt_create();
+    if (cmt == NULL) {
+        return -1;
+    }
+
     if (create_series(cmt, cardinality) == NULL) {
         cmt_destroy(cmt);
         return -1;
@@ -222,6 +234,10 @@ static int benchmark_opentelemetry(size_t cardinality, size_t operations)
 
     bytes = 0;
     cmt = cmt_create();
+    if (cmt == NULL) {
+        return -1;
+    }
+
     if (create_series(cmt, cardinality) == NULL) {
         cmt_destroy(cmt);
         return -1;

--- a/src/cmt_cat.c
+++ b/src/cmt_cat.c
@@ -673,6 +673,35 @@ static struct cmt_summary *summary_lookup(struct cmt *cmt, struct cmt_opts *opts
     return NULL;
 }
 
+static int summary_label_keys_match(struct cmt_map *left,
+                                    struct cmt_map *right)
+{
+    struct cfl_list *left_head;
+    struct cfl_list *right_head;
+    struct cmt_map_label *left_label;
+    struct cmt_map_label *right_label;
+
+    left_head = left->label_keys.next;
+    right_head = right->label_keys.next;
+
+    while (left_head != &left->label_keys &&
+           right_head != &right->label_keys) {
+        left_label = cfl_list_entry(left_head, struct cmt_map_label, _head);
+        right_label = cfl_list_entry(right_head, struct cmt_map_label, _head);
+
+        if (left_label->name == NULL || right_label->name == NULL ||
+            strcmp(left_label->name, right_label->name) != 0) {
+            return CMT_FALSE;
+        }
+
+        left_head = left_head->next;
+        right_head = right_head->next;
+    }
+
+    return left_head == &left->label_keys &&
+           right_head == &right->label_keys;
+}
+
 int cmt_cat_counter(struct cmt *cmt, struct cmt_counter *counter,
                     struct cmt_map *filtered_map)
 {
@@ -888,6 +917,11 @@ int cmt_cat_summary(struct cmt *cmt, struct cmt_summary *summary,
 
     sum = summary_lookup(cmt, opts);
     if (sum != NULL) {
+        if (!summary_label_keys_match(sum->map, map)) {
+            free(labels);
+            return -1;
+        }
+
         if (sum->quantiles_count != summary->quantiles_count) {
             free(labels);
             return -1;

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -323,11 +323,14 @@ static struct cmt_metric *map_metric_create(struct cmt_map *map, uint64_t hash,
     return NULL;
 }
 
-void cmt_map_metric_destroy(struct cmt_metric *metric)
+static void map_metric_destroy_unlocked(struct cmt_metric *metric)
 {
+    struct cmt_map *map;
     struct cfl_list *tmp;
     struct cfl_list *head;
     struct cmt_map_label *label;
+
+    map = metric->map;
 
     cfl_list_foreach_safe(head, tmp, &metric->labels) {
         label = cfl_list_entry(head, struct cmt_map_label, _head);
@@ -338,13 +341,14 @@ void cmt_map_metric_destroy(struct cmt_metric *metric)
 
     metric_release_storage(metric);
 
+    if (map != NULL && map->last_metric == metric) {
+        map->last_metric = NULL;
+    }
+
     if (metric->hash_indexed) {
-        if (metric->map != NULL) {
-            if (metric->map->last_metric == metric) {
-                metric->map->last_metric = NULL;
-            }
-            if (metric->map->indexed_metric_count > 0) {
-                metric->map->indexed_metric_count--;
+        if (map != NULL) {
+            if (map->indexed_metric_count > 0) {
+                map->indexed_metric_count--;
             }
         }
         cfl_list_del(&metric->_hash_head);
@@ -352,6 +356,22 @@ void cmt_map_metric_destroy(struct cmt_metric *metric)
 
     cfl_list_del(&metric->_head);
     free(metric);
+}
+
+void cmt_map_metric_destroy(struct cmt_metric *metric)
+{
+    struct cmt_map *map;
+
+    map = metric->map;
+    if (map != NULL) {
+        map_lock(map);
+    }
+
+    map_metric_destroy_unlocked(metric);
+
+    if (map != NULL) {
+        map_unlock(map);
+    }
 }
 
 static struct cmt_metric *map_metric_get_unlocked(struct cmt_opts *opts,
@@ -545,7 +565,7 @@ void cmt_map_metrics_expire(struct cmt_map *map, uint64_t expiration)
     cfl_list_foreach_safe(head, tmp, &map->metrics) {
         metric = cfl_list_entry(head, struct cmt_metric, _head);
         if (metric->timestamp < expiration) {
-            cmt_map_metric_destroy(metric);
+            map_metric_destroy_unlocked(metric);
         }
     }
     map_unlock(map);

--- a/tests/cat.c
+++ b/tests/cat.c
@@ -755,6 +755,37 @@ void test_summary_concatenation_preserves_series()
     cmt_destroy(dst);
 }
 
+void test_summary_concatenation_rejects_mismatched_label_schema()
+{
+    int ret;
+    double quantiles[] = {0.5, 0.9};
+    struct cmt *dst;
+    struct cmt *src;
+    struct cmt_summary *summary;
+
+    dst = cmt_create();
+    src = cmt_create();
+    TEST_ASSERT(dst != NULL);
+    TEST_ASSERT(src != NULL);
+
+    summary = cmt_summary_create(dst, "test", "cat", "schema",
+                                 "schema validation", 2, quantiles, 2,
+                                 (char *[]) {"method", "status"});
+    TEST_ASSERT(summary != NULL);
+
+    summary = cmt_summary_create(src, "test", "cat", "schema",
+                                 "schema validation", 2, quantiles, 2,
+                                 (char *[]) {"status", "method"});
+    TEST_ASSERT(summary != NULL);
+
+    ret = cmt_cat(dst, src);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(cfl_list_size(&dst->summaries) == 1);
+
+    cmt_destroy(src);
+    cmt_destroy(dst);
+}
+
 TEST_LIST = {
     {"cat", test_cat},
     {"duplicate_metrics", test_duplicate_metrics},
@@ -764,5 +795,7 @@ TEST_LIST = {
     {"histogram_populated_to_empty", test_histogram_populated_to_empty},
     {"exp_histogram_preserves_aggregation_type", test_exp_histogram_preserves_aggregation_type},
     {"summary_concatenation_preserves_series", test_summary_concatenation_preserves_series},
+    {"summary_concatenation_rejects_mismatched_label_schema",
+     test_summary_concatenation_rejects_mismatched_label_schema},
     { 0 }
 };

--- a/tests/expire.c
+++ b/tests/expire.c
@@ -353,6 +353,35 @@ void test_expire_static_metrics()
     cmt_destroy(cmt);
 }
 
+void test_destroy_unindexed_last_metric()
+{
+    struct cmt *cmt;
+    struct cmt_counter *counter;
+    struct cmt_metric *metric;
+
+    cmt = cmt_create();
+    TEST_ASSERT(cmt != NULL);
+    counter = cmt_counter_create(cmt, "test", "map", "unindexed",
+                                 "Unindexed metric destruction", 1,
+                                 (char *[]) {"label"});
+    TEST_ASSERT(counter != NULL);
+
+    metric = calloc(1, sizeof(struct cmt_metric));
+    TEST_ASSERT(metric != NULL);
+    cfl_list_init(&metric->labels);
+    cfl_list_init(&metric->_hash_head);
+    metric->map = counter->map;
+    cfl_list_add(&metric->_head, &counter->map->metrics);
+    counter->map->last_metric = metric;
+
+    cmt_map_metric_destroy(metric);
+
+    TEST_CHECK(counter->map->last_metric == NULL);
+    TEST_CHECK(cfl_list_size(&counter->map->metrics) == 0);
+
+    cmt_destroy(cmt);
+}
+
 TEST_LIST = {
     {"expire_counter"    ,   test_expire_counter},
     {"expire_gauge",         test_expire_gauge},
@@ -362,5 +391,6 @@ TEST_LIST = {
     {"expire_exp_histogram", test_epxire_exp_histogram},
     {"expire_off_by_one",    test_expire_off_by_one},
     {"expire_static_metrics", test_expire_static_metrics},
+    {"destroy_unindexed_last_metric", test_destroy_unindexed_last_metric},
     { 0 }
 };


### PR DESCRIPTION
## Summary

Fix four verified review findings affecting benchmark allocation handling, summary concatenation schema validation, and metric-map destruction safety.

All findings were checked against current `master`; none were stale.

## Changes

### Validate benchmark context allocation

Check `cmt_create()` before passing its result to `create_series()` in the lookup, update, Prometheus encoding, and OpenTelemetry encoding workloads.

The existing counter/series allocation failure cleanup remains unchanged.

### Validate summary label schemas during concatenation

`summary_lookup()` identifies an existing destination summary using metric options. Previously, the reuse path compared quantiles but did not verify label keys, allowing series with different label meanings or ordering to be merged into one map.

The reuse path now walks both label-key lists in order and rejects mismatched names, ordering, or list termination. This deliberately avoids a separate label-count comparison; completion of both list walks validates the schema length naturally. Existing quantile validation remains intact.

### Serialize metric destruction

`cmt_map_metric_destroy()` now holds the map lock while changing:

- `last_metric`;
- hash bucket links;
- `indexed_metric_count`;
- the primary metric list.

The cached `last_metric` pointer is cleared whenever it references the destroyed metric, even when that metric is not hash-indexed. This prevents the lookup fast path from retaining a freed pointer.

Expiration already acquires the map lock before traversing and deleting metrics. Calling the newly locking public function from that path would recursively acquire the spin lock and deadlock, so destruction is split into:

- a locking public `cmt_map_metric_destroy()`;
- a private `map_metric_destroy_unlocked()` used only while expiration already owns the lock.

Hash-list removal and indexed-count changes remain conditional on `hash_indexed`.

## Regression tests

- Reject concatenation of summaries with identical options and quantiles but reversed label-key ordering.
- Destroy an unindexed metric referenced by `last_metric` and verify the cache and primary list are cleared.
- Existing expiration coverage exercises the already-locked destruction path and guards against recursive-lock deadlock.

## Validation

- Full unit suite: **21/21 passed**
- Focused cat and expiration tests: **passed**
- Benchmark target: **built and executed**
- Valgrind cat suite: **0 errors, 0 leaked bytes**
- Valgrind expiration suite: **0 errors, 0 leaked bytes**
- `git diff --check`: **passed**
