### PR TITLE
opentelemetry: fix scope attribute cleanup

### DIFF
--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -1760,7 +1760,7 @@ void destroy_instrumentation_scope(Opentelemetry__Proto__Common__V1__Instrumenta
     }
 
     if (scope->attributes != NULL) {
-        destroy_attribute_list(scope->attributes);
+        otlp_kvpair_list_destroy(scope->attributes, scope->n_attributes);
     }
 
     free(scope);

--- a/tests/opentelemetry.c
+++ b/tests/opentelemetry.c
@@ -992,6 +992,102 @@ void test_opentelemetry_encode_multi_resource_scope_containers()
     cmt_destroy(cmt);
 }
 
+void test_opentelemetry_encode_scope_attributes_cleanup()
+{
+    struct cmt *cmt;
+    struct cmt_gauge *gauge;
+    struct cfl_array *resource_metrics_list;
+    struct cfl_array *scope_metrics_list;
+    struct cfl_kvlist *resource_entry;
+    struct cfl_kvlist *scope_entry;
+    struct cfl_kvlist *scope_root;
+    struct cfl_kvlist *scope_metadata;
+    struct cfl_kvlist *scope_attributes;
+    cfl_sds_t payload;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *request;
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+    if (cmt == NULL) {
+        return;
+    }
+
+    gauge = cmt_gauge_create(cmt, "ns", "sub", "scope_attributes", "g",
+                             0, NULL);
+    TEST_CHECK(gauge != NULL);
+    if (gauge == NULL) {
+        cmt_destroy(cmt);
+        return;
+    }
+    cmt_gauge_set(gauge, 123, 1.5, 0, NULL);
+
+    resource_metrics_list = cfl_array_create(1);
+    scope_metrics_list = cfl_array_create(2);
+    TEST_CHECK(resource_metrics_list != NULL && scope_metrics_list != NULL);
+    if (resource_metrics_list == NULL || scope_metrics_list == NULL) {
+        if (resource_metrics_list != NULL) {
+            cfl_array_destroy(resource_metrics_list);
+        }
+        if (scope_metrics_list != NULL) {
+            cfl_array_destroy(scope_metrics_list);
+        }
+        cmt_destroy(cmt);
+        return;
+    }
+
+    scope_entry = cfl_kvlist_create();
+    scope_root = cfl_kvlist_create();
+    scope_metadata = cfl_kvlist_create();
+    scope_attributes = cfl_kvlist_create();
+    cfl_kvlist_insert_string(scope_metadata, "name", "empty-attributes");
+    cfl_kvlist_insert_kvlist(scope_root, "metadata", scope_metadata);
+    cfl_kvlist_insert_kvlist(scope_root, "attributes", scope_attributes);
+    cfl_kvlist_insert_kvlist(scope_entry, "scope", scope_root);
+    cfl_array_append_kvlist(scope_metrics_list, scope_entry);
+
+    scope_entry = cfl_kvlist_create();
+    scope_root = cfl_kvlist_create();
+    scope_metadata = cfl_kvlist_create();
+    scope_attributes = cfl_kvlist_create();
+    cfl_kvlist_insert_string(scope_metadata, "name", "populated-attributes");
+    cfl_kvlist_insert_string(scope_attributes, "language", "c");
+    cfl_kvlist_insert_int64(scope_attributes, "generation", 2);
+    cfl_kvlist_insert_kvlist(scope_root, "metadata", scope_metadata);
+    cfl_kvlist_insert_kvlist(scope_root, "attributes", scope_attributes);
+    cfl_kvlist_insert_kvlist(scope_entry, "scope", scope_root);
+    cfl_array_append_kvlist(scope_metrics_list, scope_entry);
+
+    resource_entry = cfl_kvlist_create();
+    cfl_kvlist_insert_array(resource_entry, "scope_metrics_list",
+                            scope_metrics_list);
+    cfl_array_append_kvlist(resource_metrics_list, resource_entry);
+    cfl_kvlist_insert_array(cmt->external_metadata, "resource_metrics_list",
+                            resource_metrics_list);
+
+    payload = cmt_encode_opentelemetry_create(cmt);
+    TEST_CHECK(payload != NULL);
+    if (payload != NULL) {
+        request = opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(
+                      NULL, cfl_sds_len(payload), (uint8_t *) payload);
+        TEST_CHECK(request != NULL);
+        if (request != NULL) {
+            TEST_CHECK(request->n_resource_metrics == 1);
+            TEST_CHECK(request->resource_metrics[0]->n_scope_metrics == 2);
+            TEST_CHECK(request->resource_metrics[0]->scope_metrics[0]->scope->n_attributes == 0);
+            TEST_CHECK(request->resource_metrics[0]->scope_metrics[1]->scope->n_attributes == 2);
+            TEST_CHECK(strcmp(request->resource_metrics[0]->scope_metrics[1]->scope->attributes[0]->key,
+                              "language") == 0);
+            TEST_CHECK(strcmp(request->resource_metrics[0]->scope_metrics[1]->scope->attributes[1]->key,
+                              "generation") == 0);
+            opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(
+                request, NULL);
+        }
+        cmt_encode_opentelemetry_destroy(payload);
+    }
+
+    cmt_destroy(cmt);
+}
+
 void test_opentelemetry_api_full_roundtrip_with_msgpack()
 {
     int ret;
@@ -1900,6 +1996,7 @@ static void test_opentelemetry_omitted_null_key_label_encoded(void)
 TEST_LIST = {
     {"opentelemetry_api_full_roundtrip_with_msgpack", test_opentelemetry_api_full_roundtrip_with_msgpack},
     {"opentelemetry_encode_multi_resource_scope_containers", test_opentelemetry_encode_multi_resource_scope_containers},
+    {"opentelemetry_encode_scope_attributes_cleanup", test_opentelemetry_encode_scope_attributes_cleanup},
     {"opentelemetry_exponential_histogram",           test_opentelemetry_exponential_histogram},
     {"opentelemetry_gauge_int_and_unit_decode",       test_opentelemetry_gauge_int_and_unit_decode},
     {"opentelemetry_sum_non_monotonic_int_roundtrip", test_opentelemetry_sum_non_monotonic_int_roundtrip},


### PR DESCRIPTION
## Summary

- release heap-backed instrumentation scope attributes during OTLP encoder cleanup
- cover scopes with empty and populated attribute lists
- validate the encoded instrumentation scopes by decoding the generated protobuf

## Root cause

The OTLP arena conversion made `destroy_attribute_list()` a no-op because metric data-point attributes are arena-owned. Instrumentation scope attributes, however, are still allocated by `cfl_kvlist_to_otlp_kvpair_list()` on the heap.

`destroy_instrumentation_scope()` incorrectly routed those heap allocations through the arena-owned no-op. An empty attribute list still allocates a NULL-terminated pointer array, producing the 8-byte leak reported by Fluent Bit's Clang AddressSanitizer job. Populated lists additionally leaked their key/value objects.

The scope destructor now uses `otlp_kvpair_list_destroy()` with `scope->n_attributes`. Resource attributes, metric metadata, and exemplar filtered attributes were audited and already use matching heap cleanup on their normal and failure paths.

## Validation

- Clang AddressSanitizer and LeakSanitizer: 21/21 cmetrics tests passed
- Focused OTLP encoder suite: 15/15 tests passed
- Valgrind with definite leaks treated as errors: 21/21 test binaries passed
- `git diff --check`

The encoder currently has no deterministic allocator-injection facility, so an explicit allocation-failure injection test was not added. Existing partial-conversion and initialization failure paths use the corrected scope destructor.

Related Fluent Bit CI failure: https://github.com/fluent/fluent-bit/actions/runs/29212939918/job/86703622101?pr=12088
