### PR TITLE
docs: add repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,148 @@
-## Testing
+# CMetrics repository guide
 
-- When making code changes, run the related unit test when one is available.
+This is the canonical, vendor-neutral operating guide for automated tools and
+human contributors. Tool-specific files must point here instead of duplicating
+project rules.
 
-## Performance
+## Project role
 
-- Build benchmarks with `CMT_BENCHMARKS=ON` and an optimized Release build.
-- For performance changes, capture at least five before and five after runs on
-  the same machine with identical compiler flags and workload parameters.
-- Use `benchmarks/run-perf.sh` for the standard workloads and Linux `perf stat`
-  hardware counters. Keep only changes with repeatable improvements and no
-  relevant benchmark regressions.
+CMetrics is a standalone C library for creating, mutating, aggregating,
+encoding, and decoding metrics contexts. It is consumed by downstream projects,
+including Fluent Bit, so changes can affect public C APIs and serialized data.
+
+## Repository map
+
+- `include/cmetrics/`: installed public headers; treat layout and declarations
+  as compatibility-sensitive.
+- `src/`: metric implementations, map/index ownership, filters, and codecs.
+- `tests/`: Acutest unit tests, one CTest executable per source file.
+- `benchmarks/`: opt-in benchmark executable and Linux `perf stat` runner.
+- `docs/`: design and behavior notes; agent-neutral workflows are in `docs/ai/`.
+- `cmake/`, `CMakeLists.txt`: build, dependency, install, and packaging rules.
+- `lib/cfl`: CFL Git submodule; owns containers, SDS strings, arenas, and
+  supporting primitives.
+- `lib/fluent-otel-proto`: generated OpenTelemetry protobuf support submodule.
+- `.github/workflows/`: compiler/platform builds, tests, linting, and packages.
+
+Start architecture investigation at `include/cmetrics/cmetrics.h`, the
+metric-specific public header, and its matching `src/cmt_*.c` implementation.
+For encoding or decoding, follow the corresponding `cmt_encode_*` or
+`cmt_decode_*` pair and its tests. See `docs/architecture.md` for the component
+map and `docs/dependencies.md` for repository boundaries.
+
+## Dependency boundaries
+
+Initialize submodules before building:
+
+```sh
+git submodule update --init --recursive
+```
+
+Changes owned by CFL or fluent-otel-proto should normally land in their source
+repository first, then update the CMetrics submodule revision separately.
+Validate CMetrics standalone before updating a downstream consumer such as
+Fluent Bit. See `docs/ai/cross-repository.md` and
+`docs/ai/dependency-update.md`.
+
+## Build and test
+
+The supported build system is CMake 3.20 or newer. Local builds require Git, a
+C compiler, and the initialized submodules. Flex 2 and Bison 3 enable the
+Prometheus text decoder and its tests; CMake omits that decoder if they are not
+found. A normal development build:
+
+```sh
+cmake -S . -B build/agent -DCMT_TESTS=On -DCMT_INSTALL_TARGETS=Off
+cmake --build build/agent
+ctest --test-dir build/agent --output-on-failure
+```
+
+Repository wrappers provide the same flow:
+
+```sh
+scripts/agent-build.sh
+scripts/agent-test.sh
+scripts/agent-verify.sh
+```
+
+Use `BUILD_DIR=/path` to select another build directory. Pass extra CMake
+configuration arguments to `agent-build.sh`. Pass a CTest regular expression
+to `agent-test.sh`, for example:
+
+```sh
+scripts/agent-test.sh '^cmt-test-opentelemetry$'
+```
+
+When making code changes, run the related unit test when one is available.
+Before handoff, run `scripts/agent-verify.sh` unless the change is documentation
+only or the environment cannot build the project; report any omitted check.
+
+There is no repository-defined C formatter or C static-lint command. Preserve
+the surrounding four-space, no-tab style. Shell changes must pass `sh -n`; CI
+also runs ShellCheck. Do not claim sanitizer coverage unless the binary was
+actually compiled and executed with the requested sanitizer.
+
+## Memory and ownership
+
+- Check every allocation and preserve cleanup for partial initialization.
+- Match allocation families (`malloc`/`free`, CFL SDS create/destroy, arena
+  lifetime) and make ownership transfers explicit in code structure.
+- Exercise failure and cleanup paths for codec and container changes.
+- Treat map mutation, metric indexing, expiration, and destruction as
+  concurrency-sensitive.
+- Use AddressSanitizer or Valgrind for ownership changes; follow
+  `docs/ai/memory-safety-review.md`.
+
+## Compatibility-sensitive changes
+
+- Public declarations under `include/cmetrics/` can affect source or ABI
+  compatibility. Avoid changing established public structure layout without
+  explicit review of downstream users.
+- Internal MessagePack, OTLP protobuf, Prometheus formats, and remote write are
+  wire-sensitive. Add round-trip and malformed-input coverage where relevant.
+- Preserve integer value types, timestamps, start timestamps, label ordering,
+  and metric identity unless the change intentionally revises their contract.
+- Decoders process untrusted lengths and values: prevent overflow, oversized
+  allocation from incomplete input, desynchronization, and partial-result leaks.
+
+## Generated and vendored content
+
+- Do not edit CMake-generated `include/cmetrics/cmt_info.h` or
+  `include/cmetrics/cmt_version.h`; edit their `.in` templates or CMake version.
+- Flex/Bison outputs are generated in the build directory from
+  `src/cmt_decode_prometheus.l` and `.y`; edit the grammar sources.
+- Files marked generated under `src/external/` and
+  `include/prometheus_remote_write/` must be regenerated from their source
+  schema/toolchain, not hand-edited.
+- Do not edit submodule contents as part of a CMetrics-only change. Make the
+  change in the owning repository and update the recorded revision.
+- Build outputs and generated payloads do not belong in commits unless an
+  existing tracked fixture is intentionally updated and reviewed.
+
+## Performance changes
+
+Build benchmarks with `CMT_BENCHMARKS=ON` and an optimized Release build. Use
+`benchmarks/run-perf.sh` for standard workloads and Linux hardware counters.
+Capture at least five before and five after runs on the same machine with
+identical compiler flags and workload parameters. Keep only repeatable gains
+with no relevant regression. See `docs/ai/performance-review.md`.
+
+## Change discipline and definition of done
+
+- Keep changes scoped; preserve unrelated user work and avoid drive-by cleanup.
+- Add a regression test for a bug when practical.
+- Verify every documented command against repository files before adding it.
+- Review error paths, compatibility, generated files, and dependency ownership.
+- Run targeted tests plus the strongest practical complete validation.
+- Report root cause or intent, files changed, exact checks, compatibility
+  impact, unresolved risks, and anything not validated.
+
+Detailed workflows:
+
+- `docs/ai/investigate.md`
+- `docs/ai/bug-fix.md`
+- `docs/ai/code-review.md`
+- `docs/ai/cross-repository.md`
+- `docs/ai/dependency-update.md`
+- `docs/ai/memory-safety-review.md`
+- `docs/ai/performance-review.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/ai/bug-fix.md
+++ b/docs/ai/bug-fix.md
@@ -1,0 +1,42 @@
+# Bug-fix workflow
+
+## Purpose
+
+Produce a minimal, regression-tested fix with explicit compatibility and memory
+ownership review.
+
+## When to use
+
+Use after an observed defect has enough evidence to justify changing CMetrics.
+
+## Investigation
+
+1. Restate observed behavior and separate facts from assumptions.
+2. Identify the owning subsystem and repository.
+3. Trace the relevant public entry point, internal path, and cleanup path.
+4. Locate existing tests and reproduce the defect when practical.
+
+## Implementation
+
+1. Add a focused regression test that fails for the reported reason.
+2. Implement the smallest reasonable fix; avoid unrelated refactoring.
+3. Check allocation failure, partial initialization, cleanup, concurrency, and
+   malformed-input behavior where relevant.
+4. Review public headers and encoded formats for compatibility impact.
+
+## Validation
+
+Run the focused CTest target, then `scripts/agent-verify.sh`. Ownership fixes
+also require the applicable checks in `memory-safety-review.md`. Format changes
+require round-trip and malformed-input coverage.
+
+## Expected report
+
+Report root cause, fix, regression test, exact commands/results, compatibility
+impact, dependency impact, and unresolved risks.
+
+## Stop conditions
+
+Stop when the intended behavior requires a maintainer decision, the fix belongs
+in a dependency, a public or wire contract must change without agreement, or a
+safe reproducer cannot be created.

--- a/docs/ai/code-review.md
+++ b/docs/ai/code-review.md
@@ -1,0 +1,36 @@
+# Code-review workflow
+
+## Purpose
+
+Find actionable defects and regression risks in a proposed change.
+
+## When to use
+
+Use for pull requests, local diffs, dependency updates, and pre-release audits.
+
+## Investigation
+
+1. Establish the diff base, intended behavior, and affected public entry points.
+2. Read surrounding code and tests; verify findings against the current tree.
+3. Prioritize correctness, memory/resource ownership, cleanup paths,
+   concurrency, compatibility, malformed input, missing tests, regressions,
+   unnecessary complexity, and measurable performance impact.
+4. Trace callers before claiming a nullability, lifetime, or locking defect.
+5. Distinguish confirmed findings from questions and optional improvements.
+
+## Validation
+
+Run focused tests that can confirm or reject each high-confidence finding. For
+codec changes, inspect both encoding and decoding and relevant format
+conversions. Use sanitizer or benchmark evidence where the claim depends on it.
+
+## Expected report
+
+List findings by severity with file/line, failure scenario, evidence, and the
+smallest corrective action. Then list validation gaps and a short overall risk
+assessment. Do not bury findings in a general summary.
+
+## Stop conditions
+
+Do not request speculative changes without a concrete failure mode. Escalate
+public API, ABI, wire-format, or cross-repository policy decisions.

--- a/docs/ai/cross-repository.md
+++ b/docs/ai/cross-repository.md
@@ -1,0 +1,44 @@
+# Cross-repository workflow
+
+## Purpose
+
+Coordinate changes whose behavior or validation spans CMetrics, its submodules,
+or a downstream consumer.
+
+## When to use
+
+Use for CFL or fluent-otel-proto changes, CMetrics submodule updates, and
+consumer integrations such as Fluent Bit.
+
+## Investigation
+
+1. Identify which repository owns the behavior and which repositories consume
+   its API, ABI, generated code, or wire output.
+2. Determine compatibility impact and the required landing order.
+3. Record exact base branches, revisions, and temporary dependency revisions.
+4. Reproduce in the owning repository before changing the consumer when
+   practical.
+
+## Implementation
+
+1. Keep separate commits and pull requests per repository.
+2. Land the owning-library fix first unless a coordinated transition is needed.
+3. Update submodule or vendored revisions in a focused consumer change.
+4. Avoid copying an unmerged implementation into multiple repositories.
+
+## Validation
+
+Run standalone validation in the owning repository. Then build and test each
+consumer against the exact dependency branch/revision, including its relevant
+integration and memory-safety jobs.
+
+## Expected report
+
+Report ownership, dependency direction, revisions, landing order, standalone
+results, consumer integration results, and temporary coordination steps.
+
+## Stop conditions
+
+Stop when a required repository or CI environment is unavailable, the landing
+order could break a supported branch, or ownership/compatibility policy is
+unclear.

--- a/docs/ai/dependency-update.md
+++ b/docs/ai/dependency-update.md
@@ -1,0 +1,40 @@
+# Dependency-update workflow
+
+## Purpose
+
+Update a Git submodule revision without mixing dependency implementation changes
+into CMetrics.
+
+## When to use
+
+Use for `lib/cfl` and `lib/fluent-otel-proto` revisions.
+
+## Investigation
+
+1. Review `.gitmodules`, the current recorded revision, candidate commits/tags,
+   and the dependency's release notes or diff.
+2. Identify public API, generated protobuf, allocator, threading, compiler, and
+   platform changes consumed by CMetrics.
+3. Confirm the candidate revision exists in the dependency's upstream remote.
+
+## Implementation
+
+Update only the gitlink unless CMetrics requires a separate adaptation. Keep
+adaptations explicit and avoid editing the submodule as uncommitted content.
+
+## Validation
+
+Run `scripts/agent-verify.sh`, relevant codec tests, and compiler/platform checks
+affected by the dependency. For memory or performance changes, follow the
+specialized workflows. Validate downstream consumers after CMetrics passes.
+
+## Expected report
+
+Report old/new revisions, included upstream changes, CMetrics adaptations,
+standalone results, downstream results, and landing order.
+
+## Stop conditions
+
+Stop if the revision is not available upstream, includes unexplained generated
+changes, requires an undocumented compatibility break, or cannot be tested in
+the owning dependency first.

--- a/docs/ai/investigate.md
+++ b/docs/ai/investigate.md
@@ -1,0 +1,42 @@
+# Investigation workflow
+
+## Purpose
+
+Establish an evidence-backed explanation of CMetrics behavior without assuming
+that a code change is required.
+
+## When to use
+
+Use for bug reports, unexpected codec output, crashes, compatibility questions,
+and performance reports before selecting a fix.
+
+## Investigation
+
+1. Restate the observed and expected behavior, including platform and input.
+2. Separate reproduced facts, repository evidence, and working assumptions.
+3. Identify the owning layer: CMetrics, CFL, fluent-otel-proto, generated code,
+   or a downstream consumer.
+4. Trace from the public entry point through allocation, mutation, codec, and
+   cleanup paths. Include error exits and ownership transfers.
+5. Locate focused tests and recent changes in the same subsystem.
+6. Reproduce with the smallest representative input when practical.
+7. For malformed input, retain a non-sensitive reproducer or describe its exact
+   construction rather than relying on an external artifact.
+
+## Validation
+
+Run the closest existing CTest target. Use a sanitizer, Valgrind, or benchmarks
+only when relevant to the reported behavior. Do not infer results from CI job
+names.
+
+## Expected report
+
+Report reproduction status, owning subsystem/repository, traced code path,
+root-cause confidence, affected versions or formats when known, and remaining
+unknowns. Propose a minimal fix and test plan separately.
+
+## Stop conditions
+
+Stop and escalate when the reproducer depends on unavailable private data, the
+behavior belongs to another repository, the expected contract is ambiguous, or
+a compatibility decision is required before implementation.

--- a/docs/ai/memory-safety-review.md
+++ b/docs/ai/memory-safety-review.md
@@ -1,0 +1,39 @@
+# Memory-safety review
+
+## Purpose
+
+Validate allocation, ownership, lifetime, and cleanup changes in this C library.
+
+## When to use
+
+Use for constructors/destructors, containers, codecs, arenas, metadata,
+submodule allocator changes, and crash or leak reports.
+
+## Investigation
+
+1. Inventory allocations and their matching destructors by allocation family.
+2. Trace ownership transfers, shared/borrowed pointers, arena lifetime, and
+   partial initialization.
+3. Audit every normal and error exit, including empty collections and nested
+   values.
+4. Check concurrent mutation/destruction and untrusted length arithmetic.
+5. Add focused zero/one/many and failure-path regression cases where practical.
+
+## Validation
+
+First run the focused test normally. For AddressSanitizer, use a separate build
+with compiler/linker sanitizer flags and execute CTest with leak detection. For
+Valgrind, use a non-sanitized debug build and treat definite leaks/errors as
+failures. Record the exact compiler, flags, commands, and test count; sanitizer
+and Valgrind runs are complementary, not interchangeable.
+
+## Expected report
+
+Report the ownership model, confirmed defect, cleanup coverage, sanitizer and
+Valgrind results, allocation-failure coverage, and untested paths.
+
+## Stop conditions
+
+Stop when ownership cannot be established from callers, allocator injection is
+required but unavailable, or a proposed lifetime change affects a public
+structure without compatibility review.

--- a/docs/ai/performance-review.md
+++ b/docs/ai/performance-review.md
@@ -1,0 +1,37 @@
+# Performance-review workflow
+
+## Purpose
+
+Accept only repeatable CMetrics performance improvements without correctness or
+workload regressions.
+
+## When to use
+
+Use for map lookup/update, codec allocation, cardinality, and hot-path changes.
+
+## Investigation and implementation
+
+1. Identify the hot path and representative existing benchmark workload.
+2. Establish a correctness baseline and a performance baseline before editing.
+3. Change one material factor at a time and preserve ownership/concurrency rules.
+4. Add a benchmark workload only when existing modes cannot represent the path.
+
+## Validation
+
+Follow `benchmarks/README.md`. Build Release with `CMT_BENCHMARKS=ON`; run at
+least five alternating before/after samples on the same idle machine with the
+same compiler, flags, CPU policy, cardinality, and operations. Compare medians,
+variability, allocations when relevant, and `perf stat` counters. Run
+`scripts/agent-verify.sh` for correctness.
+
+## Expected report
+
+Report revisions, hardware/software environment, exact commands, raw samples,
+medians, percentage changes, counter changes, correctness results, and affected
+workloads. Explain any regression.
+
+## Stop conditions
+
+Do not ship noise-level, single-run, differently configured, or correctness-
+regressing results. Escalate tradeoffs that improve one supported workload while
+materially degrading another.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# CMetrics architecture
+
+CMetrics is a static C library that owns metric contexts and converts them to
+and from several metrics protocols. The installed API is declared under
+`include/cmetrics/`; implementations live under `src/`.
+
+## Core model
+
+`struct cmt` is the top-level context. Metric-family modules implement counters,
+gauges, untyped metrics, summaries, histograms, and exponential histograms.
+Each family owns a `struct cmt_map`, whose static or labeled datapoints are
+represented by `struct cmt_metric`. Labels, options, timestamps, values, and
+family-specific storage are shared by codecs and filters.
+
+The main entry points are:
+
+- `cmetrics.c`: context initialization and destruction.
+- `cmt_map.c`, `cmt_metric.c`: datapoint lookup, storage, indexing, expiration,
+  and value representation.
+- `cmt_<type>.c`: metric-family creation and mutation.
+- `cmt_cat.c`, `cmt_filter.c`: context combination and selection.
+- `cmt_encode_*.c`, `cmt_decode_*.c`: protocol boundaries.
+
+## Protocol boundaries
+
+OTLP uses generated protobuf definitions supplied by fluent-otel-proto.
+Prometheus remote write uses generated protobuf-C files in the repository.
+Prometheus text decoding uses Flex/Bison sources and build-directory generated
+parsers. CMetrics MessagePack is an internal serialized representation used by
+format-conversion and downstream flows.
+
+Changes at these boundaries should preserve metric identity, label ordering,
+numeric type, timestamps, aggregation fields, and decoder synchronization unless
+the format contract intentionally changes. Tests under `tests/encoding.c`,
+`tests/decoding.c`, `tests/opentelemetry.c`, `tests/format_conversion.c`, and
+the Prometheus-specific test files cover these paths.
+
+## Ownership and concurrency
+
+Metric families own their maps; maps own dynamic metrics and label storage.
+Some encoders create temporary heap or arena-backed protobuf structures before
+packing them into an SDS result. Allocation family and lifetime must remain
+consistent across success and partial-initialization cleanup.
+
+Map lookup, mutation, indexing, expiration, and destruction share internal
+state and must be reviewed together for concurrent access. Public structures in
+installed headers also constrain internal layout changes because downstream C
+code can compile against them.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,34 @@
+# Repository dependencies
+
+## Build dependencies
+
+- CMake 3.20 or newer configures the project.
+- A platform C compiler builds the static library and tests.
+- Flex 2 and Bison 3 generate the optional Prometheus text decoder.
+- CTest runs the Acutest executables registered by `tests/CMakeLists.txt`.
+- Linux `perf` is required only for the standard hardware-counter benchmarks.
+
+## Repository relationships
+
+CMetrics records two Git submodules:
+
+- `lib/cfl` → `fluent/cfl`: containers, SDS strings, variants, arenas, hashes,
+  atomic helpers, and other foundational C utilities.
+- `lib/fluent-otel-proto` → `fluent/fluent-otel-proto`: generated OpenTelemetry
+  protobuf-C definitions and runtime integration used by the OTLP codec.
+
+The top-level build can use system-detected copies of these libraries; otherwise
+it builds the recorded submodules. Behavior owned by either dependency should
+be fixed and validated there before updating the CMetrics gitlink.
+
+Fluent Bit is an evidenced downstream consumer of CMetrics. It is not part of
+this source tree, so consumer integration validation must use a separate Fluent
+Bit checkout with the intended CMetrics revision. A normal landing order is:
+
+1. Land and validate a dependency change in its owning repository.
+2. Update and validate CMetrics against that dependency revision.
+3. Update the CMetrics revision or bundled copy in the downstream consumer.
+4. Run the consumer's focused integration tests and applicable CI checks.
+
+Keep commits and pull requests separate per repository so each project can be
+built, reviewed, and reverted independently.

--- a/scripts/agent-build.sh
+++ b/scripts/agent-build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+build_dir=${BUILD_DIR:-"$repository_root/build/agent"}
+
+git -C "$repository_root" submodule update --init --recursive
+
+cmake -S "$repository_root" -B "$build_dir" \
+    -DCMT_TESTS=On \
+    -DCMT_INSTALL_TARGETS=Off \
+    "$@"
+
+cmake --build "$build_dir"

--- a/scripts/agent-test.sh
+++ b/scripts/agent-test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+build_dir=${BUILD_DIR:-"$repository_root/build/agent"}
+
+if [ ! -f "$build_dir/CTestTestfile.cmake" ]; then
+    echo "error: $build_dir is not configured for tests; run scripts/agent-build.sh first" >&2
+    exit 1
+fi
+
+if [ "$#" -gt 1 ]; then
+    echo "usage: $0 [ctest-regular-expression]" >&2
+    exit 2
+fi
+
+if [ "$#" -eq 1 ]; then
+    ctest --test-dir "$build_dir" --output-on-failure -R "$1"
+else
+    ctest --test-dir "$build_dir" --output-on-failure
+fi

--- a/scripts/agent-verify.sh
+++ b/scripts/agent-verify.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+for script in "$repository_root"/scripts/agent-*.sh; do
+    sh -n "$script"
+done
+
+"$repository_root/scripts/agent-build.sh" "$@"
+"$repository_root/scripts/agent-test.sh"


### PR DESCRIPTION
## Summary

- make `AGENTS.md` the canonical vendor-neutral repository guide
- add a thin `CLAUDE.md` adapter that imports the canonical guide
- document architecture, dependency boundaries, and reusable engineering workflows
- add small CMake/CTest wrappers for consistent build, targeted test, and full verification flows

## Why

The repository previously documented only a focused unit-test rule and benchmark policy for coding agents. Architecture entry points, public and wire compatibility constraints, generated-file boundaries, cross-repository ownership, memory-safety review, and a repeatable definition of done were not collected in a repository-owned operating layer.

This change preserves the existing testing and performance requirements while making them usable by human contributors, Codex, Claude Code, CI, and future tools without duplicating canonical rules in vendor-specific files.

## Validation

- `BUILD_DIR=/tmp/cmetrics-agent-verify scripts/agent-verify.sh` — 21/21 tests passed
- `BUILD_DIR=/tmp/cmetrics-agent-verify scripts/agent-test.sh '^cmt-test-opentelemetry$'` — 1/1 test passed
- `sh -n scripts/agent-build.sh scripts/agent-test.sh scripts/agent-verify.sh`
- `git diff --check`
- verified every `docs/` and `scripts/` path linked from `AGENTS.md`
- confirmed `CLAUDE.md` contains only `@AGENTS.md`

ShellCheck and `mdl` are not installed in the local environment and were not run. The full build exposed an existing `label_name may be used uninitialized` compiler warning in the OTLP encoder; this PR does not modify production code.

## Scope

No production source, public header, generated file, submodule, fixture, or CI workflow is changed.
