### PR TITLE
opentelemetry: initialize label name pointer

### DIFF
--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -3148,7 +3148,7 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     Opentelemetry__Proto__Common__V1__KeyValue        **attribute_list;
     struct cmt_label                                   *static_label;
     struct cmt_map_label                               *label_value;
-    struct cmt_map_label                               *label_name;
+    struct cmt_map_label                               *label_name = NULL;
     void                                               *data_point = NULL;
     Opentelemetry__Proto__Common__V1__KeyValue         *attribute;
     struct cmt_histogram                               *histogram;
@@ -3382,7 +3382,7 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
             return CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;
         }
 
-        if (label_name->name == NULL) {
+        if (label_name == NULL || label_name->name == NULL) {
             destroy_data_point(data_point, map->type);
 
             return CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR;


### PR DESCRIPTION
## Summary

- initialize the OTLP encoder's current label-key pointer
- reject a missing label-key pointer before dereferencing it

## Root cause

`append_sample_to_metric()` assigned `label_name` only when `map->label_count` was greater than zero. Valid control flow checks `label_name_index` against that count before dereferencing the pointer, but GCC cannot prove the relationship across the label-list loop and reports `-Wmaybe-uninitialized` in optimized builds.

The warning becomes a build failure when consumers enable `-Werror=maybe-uninitialized`. Initializing the pointer and checking it alongside the existing null-name guard makes the invariant explicit and defensively rejects an inconsistent map without changing valid encoding behavior.

## Validation

- Release build with `-O2 -Werror=maybe-uninitialized`: passed
- `ctest --test-dir /tmp/cmetrics-arena-verify -R '^cmt-test-opentelemetry$' --output-on-failure`: 1/1 passed
- `BUILD_DIR=/tmp/cmetrics-arena-verify scripts/agent-verify.sh`: 21/21 passed
- `git diff --check`
