### PR TITLE
variant_utils: bound nested MessagePack values

### DIFF
--- a/include/cmetrics/cmt_variant_utils.h
+++ b/include/cmetrics/cmt_variant_utils.h
@@ -25,6 +25,7 @@
 #define CFL_VARIANT_UTILS_MAXIMUM_FIXED_ARRAY_SIZE    100
 #define CFL_VARIANT_UTILS_INITIAL_ARRAY_SIZE          100
 #define CFL_VARIANT_UTILS_SERIALIZED_ARRAY_SIZE_LIMIT 100000
+#define CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH       32
 
 /* These are the only functions meant for general use,
  * the reason why the kvlist packing and unpacking
@@ -48,8 +49,16 @@ static inline int pack_cfl_variant(mpack_writer_t *writer,
 static inline int pack_cfl_variant_kvlist(mpack_writer_t *writer,
                                           struct cfl_kvlist *kvlist);
 
+static inline int unpack_cfl_variant_depth(mpack_reader_t *reader,
+                                           struct cfl_variant **value,
+                                           size_t depth);
+
 static inline int unpack_cfl_variant(mpack_reader_t *reader,
                                      struct cfl_variant **value);
+
+static inline int unpack_cfl_kvlist_depth(mpack_reader_t *reader,
+                                          struct cfl_kvlist **result_kvlist,
+                                          size_t depth);
 
 static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
                                     struct cfl_kvlist **result_kvlist);
@@ -234,7 +243,8 @@ static inline int unpack_cfl_variant_read_tag(mpack_reader_t *reader,
 }
 
 static inline int unpack_cfl_array(mpack_reader_t *reader,
-                                   struct cfl_array **result_array)
+                                   struct cfl_array **result_array,
+                                   size_t depth)
 {
     struct cfl_array   *internal_array;
     size_t              entry_count;
@@ -242,6 +252,10 @@ static inline int unpack_cfl_array(mpack_reader_t *reader,
     int                 result;
     size_t              index;
     mpack_tag_t         tag;
+
+    if (depth >= CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH) {
+        return -2;
+    }
 
     result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_array);
 
@@ -271,7 +285,7 @@ static inline int unpack_cfl_array(mpack_reader_t *reader,
     }
 
     for (index = 0 ; index < entry_count ; index++) {
-        result = unpack_cfl_variant(reader, &entry_value);
+        result = unpack_cfl_variant_depth(reader, &entry_value, depth + 1);
 
         if (result != 0) {
             cfl_array_destroy(internal_array);
@@ -301,8 +315,9 @@ static inline int unpack_cfl_array(mpack_reader_t *reader,
     return 0;
 }
 
-static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
-                                    struct cfl_kvlist **result_kvlist)
+static inline int unpack_cfl_kvlist_depth(mpack_reader_t *reader,
+                                          struct cfl_kvlist **result_kvlist,
+                                          size_t depth)
 {
     struct cfl_kvlist   *internal_kvlist;
     char                 key_name[256];
@@ -313,6 +328,10 @@ static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
     int                  result;
     size_t               index;
     mpack_tag_t          tag;
+
+    if (depth >= CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH) {
+        return -2;
+    }
 
     result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_map);
 
@@ -360,7 +379,7 @@ static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
             break;
         }
 
-        result = unpack_cfl_variant(reader, &key_value);
+        result = unpack_cfl_variant_depth(reader, &key_value, depth + 1);
 
         if (result != 0) {
             result = -7;
@@ -397,6 +416,12 @@ static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
     }
 
     return result;
+}
+
+static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
+                                    struct cfl_kvlist **result_kvlist)
+{
+    return unpack_cfl_kvlist_depth(reader, result_kvlist, 0);
 }
 
 static inline int unpack_cfl_variant_string(mpack_reader_t *reader,
@@ -595,12 +620,13 @@ static inline int unpack_cfl_variant_null(mpack_reader_t *reader,
 }
 
 static inline int unpack_cfl_variant_array(mpack_reader_t *reader,
-                                           struct cfl_variant **value)
+                                           struct cfl_variant **value,
+                                           size_t depth)
 {
     struct cfl_array *unpacked_array;
     int               result;
 
-    result = unpack_cfl_array(reader, &unpacked_array);
+    result = unpack_cfl_array(reader, &unpacked_array, depth);
 
     if (result != 0) {
         return result;
@@ -616,12 +642,13 @@ static inline int unpack_cfl_variant_array(mpack_reader_t *reader,
 }
 
 static inline int unpack_cfl_variant_kvlist(mpack_reader_t *reader,
-                                            struct cfl_variant **value)
+                                            struct cfl_variant **value,
+                                            size_t depth)
 {
     struct cfl_kvlist *unpacked_kvlist;
     int                result;
 
-    result = unpack_cfl_kvlist(reader, &unpacked_kvlist);
+    result = unpack_cfl_kvlist_depth(reader, &unpacked_kvlist, depth);
 
     if (result != 0) {
         return result;
@@ -636,8 +663,9 @@ static inline int unpack_cfl_variant_kvlist(mpack_reader_t *reader,
     return 0;
 }
 
-static inline int unpack_cfl_variant(mpack_reader_t *reader,
-                                     struct cfl_variant **value)
+static inline int unpack_cfl_variant_depth(mpack_reader_t *reader,
+                                           struct cfl_variant **value,
+                                           size_t depth)
 {
     mpack_type_t value_type;
     int          result;
@@ -670,10 +698,10 @@ static inline int unpack_cfl_variant(mpack_reader_t *reader,
         result = unpack_cfl_variant_null(reader, value);
     }
     else if (value_type == mpack_type_array) {
-        result = unpack_cfl_variant_array(reader, value);
+        result = unpack_cfl_variant_array(reader, value, depth);
     }
     else if (value_type == mpack_type_map) {
-        result = unpack_cfl_variant_kvlist(reader, value);
+        result = unpack_cfl_variant_kvlist(reader, value, depth);
     }
     else if (value_type == mpack_type_bin) {
         result = unpack_cfl_variant_binary(reader, value);
@@ -683,6 +711,12 @@ static inline int unpack_cfl_variant(mpack_reader_t *reader,
     }
 
     return result;
+}
+
+static inline int unpack_cfl_variant(mpack_reader_t *reader,
+                                     struct cfl_variant **value)
+{
+    return unpack_cfl_variant_depth(reader, value, 0);
 }
 
 #endif

--- a/tests/issues.c
+++ b/tests/issues.c
@@ -26,6 +26,7 @@
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_mpack_utils.h>
+#include <cmetrics/cmt_variant_utils.h>
 #include <mpack/mpack.h>
 
 #include "cmt_tests.h"
@@ -178,6 +179,70 @@ void test_truncated_msgpack_string()
     TEST_CHECK(output == NULL);
 }
 
+static void check_variant_nesting_limit(int use_maps, size_t nesting_depth,
+                                        int expected_result)
+{
+    char *buffer;
+    size_t size;
+    size_t index;
+    int result;
+    mpack_writer_t writer;
+    mpack_reader_t reader;
+    struct cfl_variant *variant;
+
+    buffer = NULL;
+    size = 0;
+    variant = NULL;
+
+    mpack_writer_init_growable(&writer, &buffer, &size);
+
+    for (index = 0; index < nesting_depth; index++) {
+        if (use_maps) {
+            mpack_start_map(&writer, 1);
+            mpack_write_cstr(&writer, "key");
+        }
+        else {
+            mpack_start_array(&writer, 1);
+        }
+    }
+
+    mpack_write_i64(&writer, 1);
+
+    for (index = 0; index < nesting_depth; index++) {
+        if (use_maps) {
+            mpack_finish_map(&writer);
+        }
+        else {
+            mpack_finish_array(&writer);
+        }
+    }
+
+    TEST_ASSERT(mpack_writer_destroy(&writer) == mpack_ok);
+
+    mpack_reader_init_data(&reader, buffer, size);
+    result = unpack_cfl_variant(&reader, &variant);
+    TEST_CHECK((result == 0) == (expected_result == 0));
+
+    if (variant != NULL) {
+        cfl_variant_destroy(variant);
+    }
+
+    mpack_reader_destroy(&reader);
+    free(buffer);
+}
+
+void test_msgpack_variant_nesting_limit()
+{
+    check_variant_nesting_limit(CFL_FALSE,
+                                CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH, 0);
+    check_variant_nesting_limit(CFL_FALSE,
+                                CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH + 1, -1);
+    check_variant_nesting_limit(CFL_TRUE,
+                                CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH, 0);
+    check_variant_nesting_limit(CFL_TRUE,
+                                CFL_VARIANT_UTILS_MAXIMUM_NESTING_DEPTH + 1, -1);
+}
+
 #ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
 
 /* issue: https://github.com/fluent/fluent-bit/issues/10761 */
@@ -212,6 +277,7 @@ TEST_LIST = {
     {"issue_54", test_issue_54},
     {"long_msgpack_labels", test_long_msgpack_labels},
     {"truncated_msgpack_string", test_truncated_msgpack_string},
+    {"msgpack_variant_nesting_limit", test_msgpack_variant_nesting_limit},
 #ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
     {"prometheus_metric_no_subsystem", test_prometheus_metric_no_subsystem},
 #endif


### PR DESCRIPTION
## Summary

- cap recursive CFL variant array and map decoding at 32 nesting levels
- keep the existing public helper entry points unchanged
- cover arrays and maps at the accepted boundary and one level beyond it

## Why

The MessagePack CFL variant decoder limited container breadth but did not limit
nesting depth. Inputs containing deeply nested metadata values could therefore
exhaust a consumer thread's native stack instead of returning a decode error.

This is particularly relevant to downstream consumers such as Fluent Bit,
where metrics metadata can be decoded on relatively small coroutine stacks.

## Validation

- `scripts/agent-test.sh '^cmt-test-issues$'`
- `scripts/agent-verify.sh` (21/21 tests passed)
- `valgrind --quiet --error-exitcode=99 --leak-check=full --show-leak-kinds=definite,indirect ../build/agent/tests/cmt-test-issues`

The change does not alter the serialized format or established helper entry
points. Values nested beyond the new safety limit are now rejected.
